### PR TITLE
Fix clippy

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -15,7 +15,7 @@ fn idl_is_parsed_as_expected() {
     let json_value: JsonValue = idl_to_serde(&idl_value.args[0]);
 
     let diff = json_patch::diff(&expected_json_value, &json_value);
-    if diff.0.len() != 0 {
+    if !(diff.0).is_empty() {
         panic!("Unexpected changes:\n{:?}", diff);
     }
 }


### PR DESCRIPTION
# Motivation
Branch protection was not set up correctly, so code that failed CI landed in main.

# Changes
Fix clippy violation in test.

# Tests
See CI