### PR TITLE
Add a typed idl2json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,6 @@ name = "idl2json"
 version = "0.8.4"
 dependencies = [
  "candid 0.8.4",
- "hex",
  "json-patch",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,6 +580,7 @@ name = "idl2json"
 version = "0.1.0"
 dependencies = [
  "candid 0.6.21",
+ "hex",
  "json-patch",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,7 @@ version = "0.8.1"
 dependencies = [
  "candid 0.8.4",
  "json-patch",
+ "serde",
  "serde_json",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "idl2json"
-version = "0.8.4"
+version = "0.8.1"
 dependencies = [
  "candid 0.8.4",
  "json-patch",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "idl2json_cli"
-version = "0.8.4"
+version = "0.8.1"
 dependencies = [
  "candid 0.8.4",
  "idl2json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,31 +194,6 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "candid"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f05b872d010281c905c4e6ff2079c1341d1e527e05f3bfab88d49ea3269def"
-dependencies = [
- "byteorder",
- "candid_derive",
- "codespan-reporting 0.9.5",
- "hex",
- "ic-types",
- "lalrpop",
- "lalrpop-util",
- "leb128",
- "logos",
- "num-bigint 0.3.3",
- "num-traits",
- "num_enum",
- "paste",
- "pretty 0.10.0",
- "serde",
- "serde_bytes",
- "thiserror",
-]
-
-[[package]]
-name = "candid"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a656d2564dd6fe665cff6051aeaa022bcee3dfc3b91ce2a573d3e593a19bb751"
@@ -218,8 +202,8 @@ dependencies = [
  "arbitrary",
  "binread",
  "byteorder",
- "candid_derive",
- "codespan-reporting 0.11.1",
+ "candid_derive 0.4.4",
+ "codespan-reporting",
  "fake",
  "hex",
  "ic-types",
@@ -227,7 +211,7 @@ dependencies = [
  "lalrpop-util",
  "leb128",
  "logos",
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-traits",
  "num_enum",
  "paste",
@@ -240,10 +224,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "candid"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244005a1917bb7614cd775ca8a5d59efeb5ac74397bb14ba29a19347ebd78591"
+dependencies = [
+ "anyhow",
+ "binread",
+ "byteorder",
+ "candid_derive 0.5.0",
+ "codespan-reporting",
+ "crc32fast",
+ "data-encoding",
+ "hex",
+ "lalrpop",
+ "lalrpop-util",
+ "leb128",
+ "logos",
+ "num-bigint",
+ "num-traits",
+ "num_enum",
+ "paste",
+ "pretty 0.10.0",
+ "serde",
+ "serde_bytes",
+ "sha2 0.10.6",
+ "thiserror",
+]
+
+[[package]]
 name = "candid_derive"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d7232a5dd836d83ae9ffd79061b42d729afab6f11bfaba7dc2a82575b686ae2"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "candid_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f1f4db7c7d04b87b70b3a35c5dc5c2c9dd73cef8bdf6760e2f18a0d45350dd"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -298,16 +323,6 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0762455306b1ed42bc651ef6a2197aabda5e1d4a43c34d5eab5c1a3634e81d"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
-name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
@@ -327,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
@@ -339,6 +354,22 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array 0.14.4",
+ "typenum",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "derivative"
@@ -371,7 +402,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_cbor",
- "sha2",
+ "sha2 0.9.8",
  "url",
 ]
 
@@ -408,6 +439,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array 0.14.4",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer 0.10.3",
+ "crypto-common",
 ]
 
 [[package]]
@@ -571,15 +612,15 @@ dependencies = [
  "hex",
  "serde",
  "serde_bytes",
- "sha2",
+ "sha2 0.9.8",
  "thiserror",
 ]
 
 [[package]]
 name = "idl2json"
-version = "0.1.0"
+version = "0.8.4"
 dependencies = [
- "candid 0.6.21",
+ "candid 0.8.4",
  "hex",
  "json-patch",
  "serde_json",
@@ -587,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "idl2json_cli"
-version = "0.1.0"
+version = "0.8.4"
 dependencies = [
- "candid 0.6.21",
+ "candid 0.8.4",
  "idl2json",
  "serde_json",
 ]
@@ -800,17 +841,6 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
@@ -818,6 +848,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -1278,6 +1309,17 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
 ]
 
 [[package]]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.64.0"
+components = ["rustfmt", "clippy"]

--- a/samples/internet_identity.did
+++ b/samples/internet_identity.did
@@ -1,0 +1,221 @@
+type UserNumber = nat64;
+type PublicKey = blob;
+type CredentialId = blob;
+type DeviceKey = PublicKey;
+type UserKey = PublicKey;
+type SessionKey = PublicKey;
+type FrontendHostname = text;
+type Timestamp = nat64;
+
+type HeaderField = record {
+    text;
+    text;
+};
+
+type HttpRequest = record {
+    method: text;
+    url: text;
+    headers: vec HeaderField;
+    body: blob;
+};
+
+type HttpResponse = record {
+    status_code: nat16;
+    headers: vec HeaderField;
+    body: blob;
+    streaming_strategy: opt StreamingStrategy;
+};
+
+type StreamingCallbackHttpResponse = record {
+    body: blob;
+    token: opt Token;
+};
+
+type Token = record {};
+
+type StreamingStrategy = variant {
+    Callback: record {
+        callback: func (Token) -> (StreamingCallbackHttpResponse) query;
+        token: Token;
+    };
+};
+
+type Purpose = variant {
+    recovery;
+    authentication;
+};
+
+type KeyType = variant {
+    unknown;
+    platform;
+    cross_platform;
+    seed_phrase;
+};
+
+// This describes whether a device is "protected" or not.
+// When protected, a device can only be updated or removed if the
+// user is authenticated with that very device.
+type DeviceProtection = variant {
+    protected;
+    unprotected;
+};
+
+type Challenge = record {
+    png_base64: text;
+    challenge_key: ChallengeKey;
+};
+
+type DeviceData = record {
+    pubkey : DeviceKey;
+    alias : text;
+    credential_id : opt CredentialId;
+    purpose: Purpose;
+    key_type: KeyType;
+    protection: DeviceProtection;
+};
+
+type RegisterResponse = variant {
+    // A new user was successfully registered.
+    registered: record {
+        user_number: UserNumber;
+    };
+    // No more registrations are possible in this instance of the II service canister.
+    canister_full;
+    // The challenge was not successful.
+    bad_challenge;
+};
+
+type AddTentativeDeviceResponse = variant {
+    // The device was tentatively added.
+    added_tentatively: record {
+        verification_code: text;
+        device_registration_timeout: Timestamp;
+    };
+    // Device registration mode is off, either due to timeout or because it was never enabled.
+    device_registration_mode_off;
+    // There is another device already added tentatively
+    another_device_tentatively_added;
+};
+
+type VerifyTentativeDeviceResponse = variant {
+    // The device was successfully verified.
+    verified;
+    // Wrong verification code entered. Retry with correct code.
+    wrong_code: record {
+        retries_left: nat8
+    };
+    // Device registration mode is off, either due to timeout or because it was never enabled.
+    device_registration_mode_off;
+    // There is no tentative device to be verified.
+    no_device_to_verify;
+};
+
+type Delegation = record {
+    pubkey: PublicKey;
+    expiration: Timestamp;
+    targets: opt vec principal;
+};
+
+type SignedDelegation = record {
+    delegation: Delegation;
+    signature: blob;
+};
+
+type GetDelegationResponse = variant {
+    // The signed delegation was successfully retrieved.
+    signed_delegation: SignedDelegation;
+
+    // The signature is not ready. Maybe retry by calling `prepare_delegation`
+    no_such_delegation
+};
+
+type InternetIdentityStats = record {
+    users_registered: nat64;
+    assigned_user_number_range: record {
+        nat64;
+        nat64;
+    };
+    archive_info: ArchiveInfo;
+    canister_creation_cycles_cost: nat64;
+};
+
+// Information about the archive.
+type ArchiveInfo = record {
+    // Canister id of the archive or empty if no archive has been deployed yet.
+    archive_canister : opt principal;
+    // Expected hash of the archive wasm module. II will accept wasm modules hashing to this hash in the canister call
+    // deploy_archive. The actual installed archive wasm hash might be different if the archive has not yet been upgraded.
+    // When empty, deployment of the archive is disabled and II will not accept any wasm module.
+    expected_wasm_hash: opt blob;
+};
+
+// Init arguments of II which can be supplied on install and upgrade.
+// Setting a value to null keeps the previous value.
+type InternetIdentityInit = record {
+    // Set lowest and highest anchor
+    assigned_user_number_range : opt record {
+        nat64;
+        nat64;
+    };
+    // Set the module hash of the archive canister
+    archive_module_hash : opt blob;
+    // Set the amounts of cycles sent with the create canister message.
+    // This is configurable because in the staging environment cycles are required.
+    // The canister creation cost on mainnet is currently 100'000'000'000 cycles. If this value is higher thant the
+    // canister creation cost, the newly created canister will keep extra cycles.
+    canister_creation_cycles_cost : opt nat64;
+};
+
+type ChallengeKey = text;
+
+type ChallengeResult = record {
+    key : ChallengeKey;
+    chars : text;
+};
+
+type DeviceRegistrationInfo = record {
+    tentative_device : opt DeviceData;
+    expiration: Timestamp;
+};
+
+type IdentityAnchorInfo = record {
+    devices : vec DeviceData;
+    device_registration: opt DeviceRegistrationInfo;
+};
+
+type DeployArchiveResult = variant {
+    // The archive was deployed successfully and the supplied wasm module has been installed. The principal of the archive
+    // canister is returned.
+    success: principal;
+    // Initial archive creation is already in progress.
+    creation_in_progress;
+    // Archive deployment failed. An error description is returned.
+    failed: text;
+};
+
+service : (opt InternetIdentityInit) -> {
+    init_salt: () -> ();
+    create_challenge : () -> (Challenge);
+    register : (DeviceData, ChallengeResult) -> (RegisterResponse);
+    add : (UserNumber, DeviceData) -> ();
+    update : (UserNumber, DeviceKey, DeviceData) -> ();
+    remove : (UserNumber, DeviceKey) -> ();
+    // Returns all devices of the user (authentication and recovery) but no information about device registrations.
+    // Note: Will be changed in the future to be more consistent with get_anchor_info.
+    lookup : (UserNumber) -> (vec DeviceData) query;
+    get_anchor_info : (UserNumber) -> (IdentityAnchorInfo);
+    get_principal : (UserNumber, FrontendHostname) -> (principal) query;
+    stats : () -> (InternetIdentityStats) query;
+
+    enter_device_registration_mode : (UserNumber) -> (Timestamp);
+    exit_device_registration_mode : (UserNumber) -> ();
+    add_tentative_device : (UserNumber, DeviceData) -> (AddTentativeDeviceResponse);
+    verify_tentative_device : (UserNumber, verification_code: text) -> (VerifyTentativeDeviceResponse);
+
+    prepare_delegation : (UserNumber, FrontendHostname, SessionKey, maxTimeToLive : opt nat64) -> (UserKey, Timestamp);
+    get_delegation: (UserNumber, FrontendHostname, SessionKey, Timestamp) -> (GetDelegationResponse) query;
+
+    http_request: (request: HttpRequest) -> (HttpResponse) query;
+
+    deploy_archive: (wasm: blob) -> (DeployArchiveResult);
+}

--- a/src/idl2json/Cargo.toml
+++ b/src/idl2json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idl2json"
-version = "0.8.4" # Should match the candid version below and in idl2json_cli.
+version = "0.8.1" # Should match the candid version below and in idl2json_cli.
 authors = ["dfinity <sdk@dfinity.org>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-candid = "0.8.4"
+candid = "0.8.1"
 serde_json = "^1.0"
 
 [dev-dependencies]

--- a/src/idl2json/Cargo.toml
+++ b/src/idl2json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idl2json"
-version = "0.1.0"
+version = "0.8.4" # Should match the candid version below and in idl2json_cli.
 authors = ["dfinity <sdk@dfinity.org>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-candid = "0.6.21"
+candid = "0.8.4"
 serde_json = "^1.0"
 
 [dev-dependencies]

--- a/src/idl2json/Cargo.toml
+++ b/src/idl2json/Cargo.toml
@@ -13,3 +13,4 @@ serde_json = "^1.0"
 
 [dev-dependencies]
 json-patch = "0.2.6"
+hex = "0.4.3"

--- a/src/idl2json/Cargo.toml
+++ b/src/idl2json/Cargo.toml
@@ -13,4 +13,3 @@ serde_json = "^1.0"
 
 [dev-dependencies]
 json-patch = "0.2.6"
-hex = "0.4.3"

--- a/src/idl2json/Cargo.toml
+++ b/src/idl2json/Cargo.toml
@@ -13,3 +13,4 @@ serde_json = "^1.0"
 
 [dev-dependencies]
 json-patch = "0.2.6"
+serde = "1"

--- a/src/idl2json/examples/init.rs
+++ b/src/idl2json/examples/init.rs
@@ -5,8 +5,6 @@ use candid::{
     },
     Decode, IDLProg,
 };
-use core::str;
-use hex::FromHex;
 use idl2json::{idl2json, idl2json_with_weak_names};
 use std::str::FromStr;
 
@@ -18,6 +16,9 @@ fn main() {
             .expect("Could not read did file");
         IDLProg::from_str(&did_as_str).expect("Failed to parse did")
     };
+    // TODO: This is still unimplemented in candid, but should be available soon.
+    //let rust = idl_to_rust(&prog, &Config::default()).expect("Could not compute rust");
+    //println!("Rust: {rust}");
     let idl_type = prog
         .decs
         .iter()
@@ -32,8 +33,6 @@ fn main() {
         .expect("Failed to get idltype");
     let idl_type = IDLType::OptT(Box::new(idl_type));
     println!("Type: {:?}\n\n", &idl_type);
-    let hex_bytes = "4449444C056E016C02C488BFD70102F7F5CBFB07046E036D7B6E780100010120F691F269DD66AA4FC44E6916AEFEE03BB7FEB821AEF43467526974F470CD4B07010010A5D4E8000000";
-    //let buffer = <[u8; 12]>::from_hex(hex_bytes);
     let buffer = [
         68, 73, 68, 76, 5, 110, 1, 108, 2, 196, 136, 191, 215, 1, 2, 247, 245, 203, 251, 7, 4, 110,
         3, 109, 123, 110, 120, 1, 0, 1, 1, 32, 246, 145, 242, 105, 221, 102, 170, 79, 196, 78, 105,

--- a/src/idl2json/examples/init.rs
+++ b/src/idl2json/examples/init.rs
@@ -41,7 +41,6 @@ fn main() {
         75, 7, 1, 0, 16, 165, 212, 232, 0, 0, 0,
     ];
     println!("data: {:?}\n\n", &buffer);
-    //let idl_value: (IDLValue) = buffer[..].parse().expect("Could not parse bytes");
     let idl_value = Decode!(&buffer[..], IDLValue).expect("Failed to parse buffer");
     println!("Value: {:?}\n\n", idl_value);
     println!(

--- a/src/idl2json/examples/init.rs
+++ b/src/idl2json/examples/init.rs
@@ -1,37 +1,57 @@
+use candid::{
+    parser::{
+        types::{Dec, IDLType},
+        value::IDLValue,
+    },
+    Decode, IDLProg,
+};
 use core::str;
-use std::str::FromStr;
-use candid::{IDLProg, parser::{types::{Dec, IDLType}, value::IDLValue}, Decode};
 use hex::FromHex;
 use idl2json::{idl2json, idl2json_with_weak_names};
+use std::str::FromStr;
 
 /// Converts some sample bytes
 fn main() {
-   let type_name = "InternetIdentityInit";
-   let prog = {
-      let did_as_str = std::fs::read_to_string("../../samples/internet_identity.did").expect("Could not read did file");
-      IDLProg::from_str(&did_as_str).expect("Failed to parse did")
-   };
-   let idl_type = prog
-                    .decs
-                    .iter()
-                    .find_map(|x| {
-                        if let Dec::TypD(y) = x {
-                            if y.id == type_name {
-                                return Some(y.typ.clone());
-                            }
-                        }
-                        None
-                    }).expect("Failed to get idltype");
-   let idl_type = IDLType::OptT(Box::new(idl_type));
-   println!("Type: {:?}\n\n", &idl_type);
-   let hex_bytes = "4449444C056E016C02C488BFD70102F7F5CBFB07046E036D7B6E780100010120F691F269DD66AA4FC44E6916AEFEE03BB7FEB821AEF43467526974F470CD4B07010010A5D4E8000000";
-   //let buffer = <[u8; 12]>::from_hex(hex_bytes);
-   let buffer = [68,73,68,76,5,110,1,108,2,196,136,191,215,1,2,247,245,203,251,7,4,110,3,109,123,110,120,1,0,1,1,32,246,145,242,105,221,102,170,79,196,78,105,22,174,254,224,59,183,254,184,33,174,244,52,103,82,105,116,244,112,205,75,7,1,0,16,165,212,232,0,0,0];
-   println!("data: {:?}\n\n", &buffer);
-   //let idl_value: (IDLValue) = buffer[..].parse().expect("Could not parse bytes");
-   let idl_value = Decode!(&buffer[..], IDLValue).expect("Failed to parse buffer");
-   println!("Value: {:?}\n\n", idl_value);
-   println!("Untyped conversion: {:?}\n\n", serde_json::to_string(&idl2json(&idl_value)).expect("Failed to stringify"));
+    let type_name = "InternetIdentityInit";
+    let prog = {
+        let did_as_str = std::fs::read_to_string("../../samples/internet_identity.did")
+            .expect("Could not read did file");
+        IDLProg::from_str(&did_as_str).expect("Failed to parse did")
+    };
+    let idl_type = prog
+        .decs
+        .iter()
+        .find_map(|x| {
+            if let Dec::TypD(y) = x {
+                if y.id == type_name {
+                    return Some(y.typ.clone());
+                }
+            }
+            None
+        })
+        .expect("Failed to get idltype");
+    let idl_type = IDLType::OptT(Box::new(idl_type));
+    println!("Type: {:?}\n\n", &idl_type);
+    let hex_bytes = "4449444C056E016C02C488BFD70102F7F5CBFB07046E036D7B6E780100010120F691F269DD66AA4FC44E6916AEFEE03BB7FEB821AEF43467526974F470CD4B07010010A5D4E8000000";
+    //let buffer = <[u8; 12]>::from_hex(hex_bytes);
+    let buffer = [
+        68, 73, 68, 76, 5, 110, 1, 108, 2, 196, 136, 191, 215, 1, 2, 247, 245, 203, 251, 7, 4, 110,
+        3, 109, 123, 110, 120, 1, 0, 1, 1, 32, 246, 145, 242, 105, 221, 102, 170, 79, 196, 78, 105,
+        22, 174, 254, 224, 59, 183, 254, 184, 33, 174, 244, 52, 103, 82, 105, 116, 244, 112, 205,
+        75, 7, 1, 0, 16, 165, 212, 232, 0, 0, 0,
+    ];
+    println!("data: {:?}\n\n", &buffer);
+    //let idl_value: (IDLValue) = buffer[..].parse().expect("Could not parse bytes");
+    let idl_value = Decode!(&buffer[..], IDLValue).expect("Failed to parse buffer");
+    println!("Value: {:?}\n\n", idl_value);
+    println!(
+        "Untyped conversion: {:?}\n\n",
+        serde_json::to_string(&idl2json(&idl_value)).expect("Failed to stringify")
+    );
 
-   println!("Typed conversion: {}\n\n", serde_json::to_string(&idl2json_with_weak_names(&idl_value, &idl_type)).expect("Failed to stringify"));
+    println!(
+        "Typed conversion: {}\n\n",
+        serde_json::to_string(&idl2json_with_weak_names(&idl_value, &idl_type))
+            .expect("Failed to stringify")
+    );
 }

--- a/src/idl2json/examples/init.rs
+++ b/src/idl2json/examples/init.rs
@@ -1,0 +1,37 @@
+use core::str;
+use std::str::FromStr;
+use candid::{IDLProg, parser::{types::{Dec, IDLType}, value::IDLValue}, Decode};
+use hex::FromHex;
+use idl2json::{idl2json, idl2json_with_weak_names};
+
+/// Converts some sample bytes
+fn main() {
+   let type_name = "InternetIdentityInit";
+   let prog = {
+      let did_as_str = std::fs::read_to_string("../../samples/internet_identity.did").expect("Could not read did file");
+      IDLProg::from_str(&did_as_str).expect("Failed to parse did")
+   };
+   let idl_type = prog
+                    .decs
+                    .iter()
+                    .find_map(|x| {
+                        if let Dec::TypD(y) = x {
+                            if y.id == type_name {
+                                return Some(y.typ.clone());
+                            }
+                        }
+                        None
+                    }).expect("Failed to get idltype");
+   let idl_type = IDLType::OptT(Box::new(idl_type));
+   println!("Type: {:?}\n\n", &idl_type);
+   let hex_bytes = "4449444C056E016C02C488BFD70102F7F5CBFB07046E036D7B6E780100010120F691F269DD66AA4FC44E6916AEFEE03BB7FEB821AEF43467526974F470CD4B07010010A5D4E8000000";
+   //let buffer = <[u8; 12]>::from_hex(hex_bytes);
+   let buffer = [68,73,68,76,5,110,1,108,2,196,136,191,215,1,2,247,245,203,251,7,4,110,3,109,123,110,120,1,0,1,1,32,246,145,242,105,221,102,170,79,196,78,105,22,174,254,224,59,183,254,184,33,174,244,52,103,82,105,116,244,112,205,75,7,1,0,16,165,212,232,0,0,0];
+   println!("data: {:?}\n\n", &buffer);
+   //let idl_value: (IDLValue) = buffer[..].parse().expect("Could not parse bytes");
+   let idl_value = Decode!(&buffer[..], IDLValue).expect("Failed to parse buffer");
+   println!("Value: {:?}\n\n", idl_value);
+   println!("Untyped conversion: {:?}\n\n", idl2json(&idl_value));
+
+   println!("Typed conversion: {}\n\n", serde_json::to_string(&idl2json_with_weak_names(&idl_value, &idl_type)).expect("Failed to stringify"));
+}

--- a/src/idl2json/examples/init.rs
+++ b/src/idl2json/examples/init.rs
@@ -1,3 +1,4 @@
+//! Example of how to convert binary candid to JSON using a schema
 use candid::{
     parser::{
         types::{Dec, IDLType},
@@ -8,7 +9,7 @@ use candid::{
 use idl2json::{idl2json, idl2json_with_weak_names};
 use std::str::FromStr;
 
-/// Converts some sample bytes
+/// Converts some sample candid bytes to JSON using a .did file.
 fn main() {
     let type_name = "InternetIdentityInit";
     let prog = {

--- a/src/idl2json/examples/init.rs
+++ b/src/idl2json/examples/init.rs
@@ -31,7 +31,7 @@ fn main() {
    //let idl_value: (IDLValue) = buffer[..].parse().expect("Could not parse bytes");
    let idl_value = Decode!(&buffer[..], IDLValue).expect("Failed to parse buffer");
    println!("Value: {:?}\n\n", idl_value);
-   println!("Untyped conversion: {:?}\n\n", idl2json(&idl_value));
+   println!("Untyped conversion: {:?}\n\n", serde_json::to_string(&idl2json(&idl_value)).expect("Failed to stringify"));
 
    println!("Typed conversion: {}\n\n", serde_json::to_string(&idl2json_with_weak_names(&idl_value, &idl_type)).expect("Failed to stringify"));
 }

--- a/src/idl2json/src/candid_types.rs
+++ b/src/idl2json/src/candid_types.rs
@@ -1,0 +1,58 @@
+use candid::{
+    parser::types::{IDLType, PrimType, TypeField},
+    types::internal::{Field as InternalField, Type as InternalType},
+};
+
+/// Deriving CandidType on a RustType provides
+/// the Candid type, however only as an internal
+/// type incompatible with IDLType.  Let's convert.
+///
+/// There may be an existing conversion function
+/// but I cannot see it.
+pub fn internal_candid_type_to_idl_type(internal_type: &InternalType) -> IDLType {
+    match internal_type {
+        InternalType::Null => IDLType::PrimT(PrimType::Null),
+        InternalType::Bool => IDLType::PrimT(PrimType::Null),
+        InternalType::Nat => IDLType::PrimT(PrimType::Nat),
+        InternalType::Int => IDLType::PrimT(PrimType::Int),
+        InternalType::Nat8 => IDLType::PrimT(PrimType::Nat8),
+        InternalType::Nat16 => IDLType::PrimT(PrimType::Nat16),
+        InternalType::Nat32 => IDLType::PrimT(PrimType::Nat32),
+        InternalType::Nat64 => IDLType::PrimT(PrimType::Nat64),
+        InternalType::Int8 => IDLType::PrimT(PrimType::Int8),
+        InternalType::Int16 => IDLType::PrimT(PrimType::Int16),
+        InternalType::Int32 => IDLType::PrimT(PrimType::Int32),
+        InternalType::Int64 => IDLType::PrimT(PrimType::Int64),
+        InternalType::Float32 => IDLType::PrimT(PrimType::Float32),
+        InternalType::Float64 => IDLType::PrimT(PrimType::Float64),
+        InternalType::Text => IDLType::PrimT(PrimType::Text),
+        InternalType::Reserved => IDLType::PrimT(PrimType::Reserved),
+        InternalType::Empty => IDLType::PrimT(PrimType::Empty),
+        InternalType::Knot(_) => unimplemented!(),
+        InternalType::Var(_) => unimplemented!(),
+        InternalType::Unknown => unimplemented!(),
+        InternalType::Opt(boxed_type) => {
+            IDLType::OptT(Box::new(internal_candid_type_to_idl_type(boxed_type)))
+        }
+        InternalType::Vec(items) => {
+            IDLType::VecT(Box::new(internal_candid_type_to_idl_type(items)))
+        }
+        InternalType::Record(fields) => {
+            IDLType::RecordT(fields.iter().map(internal_field_type_to_idl_type).collect())
+        }
+        InternalType::Variant(fields) => {
+            IDLType::VariantT(fields.iter().map(internal_field_type_to_idl_type).collect())
+        }
+        InternalType::Func(_) => unimplemented!(),
+        InternalType::Service(_) => unimplemented!(),
+        InternalType::Class(_, _) => unimplemented!(),
+        InternalType::Principal => IDLType::PrincipalT,
+    }
+}
+
+fn internal_field_type_to_idl_type(field: &InternalField) -> TypeField {
+    TypeField {
+        label: field.id.clone(),
+        typ: internal_candid_type_to_idl_type(&field.ty),
+    }
+}

--- a/src/idl2json/src/lib.rs
+++ b/src/idl2json/src/lib.rs
@@ -1,3 +1,4 @@
+//! Library of IDL (candid) to JSON conversion functions.
 mod typed_conversion;
 mod untyped_conversion;
 pub use serde_json::Value as JsonValue;

--- a/src/idl2json/src/lib.rs
+++ b/src/idl2json/src/lib.rs
@@ -1,55 +1,7 @@
-use candid::parser::value::IDLValue;
-use serde_json::value::Value as JsonValue;
+mod typed_conversion;
+mod untyped_conversion;
+pub use untyped_conversion::idl2json;
+pub use typed_conversion::idl2json_with_weak_names;
+pub use serde_json::Value as JsonValue;
 #[cfg(test)]
 mod test;
-
-/// Converts a candid IDLValue to a serde JsonValue
-pub fn idl2json(idl: &IDLValue) -> JsonValue {
-    match idl {
-        IDLValue::Bool(bool) => JsonValue::Bool(*bool),
-        IDLValue::Null => JsonValue::Null,
-        IDLValue::Text(s) => JsonValue::String(s.clone()),
-        IDLValue::Number(s) => JsonValue::String(s.clone()), // Unspecified number type
-        IDLValue::Float64(f) => {
-            JsonValue::Number(serde_json::Number::from_f64(*f).expect("A float's a float"))
-        }
-        IDLValue::Opt(value) => JsonValue::Array(vec![idl2json(value)]),
-        IDLValue::Vec(value) => JsonValue::Array(value.iter().map(idl2json).collect()),
-        IDLValue::Record(value) => JsonValue::Object(
-            value
-                .iter()
-                .map(|field| (format!("{}", field.id), idl2json(&field.val)))
-                .collect(),
-        ),
-        IDLValue::Variant(field, _) => JsonValue::Object(
-            vec![(format!("{}", field.id), idl2json(&field.val))]
-                .into_iter()
-                .collect(),
-        ),
-        IDLValue::Principal(p) => JsonValue::String(format!("{}", p)),
-        IDLValue::Service(p) => JsonValue::String(format!("{}", p)),
-        IDLValue::Func(p, c) => JsonValue::Object(
-            vec![
-                ("principal".to_string(), JsonValue::String(format!("{}", p))),
-                ("code".to_string(), JsonValue::String(c.to_string())),
-            ]
-            .into_iter()
-            .collect(),
-        ),
-        IDLValue::None => JsonValue::Array(vec![]),
-        IDLValue::Int(i) => JsonValue::String(format!("{}", i)),
-        IDLValue::Nat(i) => JsonValue::String(format!("{}", i)),
-        IDLValue::Nat8(i) => JsonValue::Number(serde_json::Number::from(*i)),
-        IDLValue::Nat16(i) => JsonValue::Number(serde_json::Number::from(*i)),
-        IDLValue::Nat32(i) => JsonValue::Number(serde_json::Number::from(*i)),
-        IDLValue::Nat64(i) => JsonValue::String(format!("{}", i)),
-        IDLValue::Int8(i) => JsonValue::Number(serde_json::Number::from(*i)),
-        IDLValue::Int16(i) => JsonValue::Number(serde_json::Number::from(*i)),
-        IDLValue::Int32(i) => JsonValue::Number(serde_json::Number::from(*i)),
-        IDLValue::Int64(i) => JsonValue::String(format!("{}", i)),
-        IDLValue::Float32(f) => {
-            JsonValue::Number(serde_json::Number::from_f64(*f as f64).expect("A float's a float"))
-        }
-        IDLValue::Reserved => panic!("Unimplemented: {:?}", idl),
-    }
-}

--- a/src/idl2json/src/lib.rs
+++ b/src/idl2json/src/lib.rs
@@ -1,7 +1,7 @@
 mod typed_conversion;
 mod untyped_conversion;
-pub use untyped_conversion::idl2json;
-pub use typed_conversion::idl2json_with_weak_names;
 pub use serde_json::Value as JsonValue;
+pub use typed_conversion::idl2json_with_weak_names;
+pub use untyped_conversion::idl2json;
 #[cfg(test)]
 mod test;

--- a/src/idl2json/src/lib.rs
+++ b/src/idl2json/src/lib.rs
@@ -1,4 +1,5 @@
 //! Library of IDL (candid) to JSON conversion functions.
+pub mod candid_types;
 mod typed_conversion;
 mod untyped_conversion;
 pub use serde_json::Value as JsonValue;

--- a/src/idl2json/src/test.rs
+++ b/src/idl2json/src/test.rs
@@ -51,6 +51,7 @@ fn sample_idls_are_parsed_as_expected() {
 #[test]
 fn sample_binaries_are_parsed_with_did() {
     // The inputs:
+    // .. At the time of writing, this type is `InternetIdentityInit` from `internet_identity.did`.
     let idl_type = IDLType::OptT(Box::new(IDLType::RecordT(vec![
         TypeField {
             label: Label::Named("archive_module_hash".to_string()),

--- a/src/idl2json/src/test.rs
+++ b/src/idl2json/src/test.rs
@@ -1,5 +1,5 @@
 use crate::{idl2json, JsonValue};
-use candid::IDLArgs;
+use candid::{parser::types::IDLType, IDLArgs};
 use std::fs;
 
 /// Returns the absolute path to a file in the samples directory.
@@ -9,6 +9,10 @@ macro_rules! sample_file {
     };
 }
 
+/// Verifies that the idl at the given filename is parsed to the JSON at the other filename.
+///
+/// - Formatting differences are ignored.
+/// - No interface definition file (.did file) is employed.
 fn idl_is_parsed_as_expected(idl_filename: &str, json_filename: &str) {
     let expected_json_string: String =
         fs::read_to_string(sample_file!(json_filename)).expect("Could not read sample JSON");
@@ -29,8 +33,25 @@ fn idl_is_parsed_as_expected(idl_filename: &str, json_filename: &str) {
     }
 }
 
+/// Checks untyped idl to json conversion test vectors.
 #[test]
 fn sample_idls_are_parsed_as_expected() {
     idl_is_parsed_as_expected("proposal.idl", "proposal.json");
     idl_is_parsed_as_expected("all_types.idl", "all_types.json");
 }
+
+/*
+/// Verifies that the buffer is parsed to the expected JSON using the provided .did.
+#[test]
+fn sample_binaries_are_parsed_with_did() {
+    let idl_type = IDLType::OptT(Box::new(IDLType::RecordT(vec![TypeField { label: Named("archive_module_hash"), typ: OptT(VecT(PrimT(Nat8))) }, TypeField { label: Named("assigned_user_number_range"), typ: OptT(RecordT([TypeField { label: Unnamed(0), typ: PrimT(Nat64) }, TypeField { label: Unnamed(1), typ: PrimT(Nat64) }])) }, TypeField { label: Named("canister_creation_cycles_cost"), typ: OptT(PrimT(Nat64)) }])));
+    let test_vectors: [(&[i8], &str, &IDLType)] = [
+        (&[
+            68, 73, 68, 76, 5, 110, 1, 108, 2, 196, 136, 191, 215, 1, 2, 247, 245, 203, 251, 7, 4, 110,
+            3, 109, 123, 110, 120, 1, 0, 1, 1, 32, 246, 145, 242, 105, 221, 102, 170, 79, 196, 78, 105,
+            22, 174, 254, 224, 59, 183, 254, 184, 33, 174, 244, 52, 103, 82, 105, 116, 244, 112, 205,
+            75, 7, 1, 0, 16, 165, 212, 232, 0, 0, 0,
+        ], "[{"archive_module_hash":[[246,145,242,105,221,102,170,79,196,78,105,22,174,254,224,59,183,254,184,33,174,244,52,103,82,105,116,244,112,205,75,7]],"canister_creation_cycles_cost":["1000000000000"]}]")
+    ];
+}
+*/

--- a/src/idl2json/src/test.rs
+++ b/src/idl2json/src/test.rs
@@ -1,5 +1,9 @@
 use crate::{idl2json, JsonValue};
-use candid::{parser::types::IDLType, IDLArgs};
+use candid::{
+    parser::types::{IDLType, PrimType, TypeField},
+    types::internal::Label,
+    IDLArgs,
+};
 use std::fs;
 
 /// Returns the absolute path to a file in the samples directory.
@@ -40,18 +44,39 @@ fn sample_idls_are_parsed_as_expected() {
     idl_is_parsed_as_expected("all_types.idl", "all_types.json");
 }
 
-/*
 /// Verifies that the buffer is parsed to the expected JSON using the provided .did.
 #[test]
 fn sample_binaries_are_parsed_with_did() {
-    let idl_type = IDLType::OptT(Box::new(IDLType::RecordT(vec![TypeField { label: Named("archive_module_hash"), typ: OptT(VecT(PrimT(Nat8))) }, TypeField { label: Named("assigned_user_number_range"), typ: OptT(RecordT([TypeField { label: Unnamed(0), typ: PrimT(Nat64) }, TypeField { label: Unnamed(1), typ: PrimT(Nat64) }])) }, TypeField { label: Named("canister_creation_cycles_cost"), typ: OptT(PrimT(Nat64)) }])));
-    let test_vectors: [(&[i8], &str, &IDLType)] = [
-        (&[
-            68, 73, 68, 76, 5, 110, 1, 108, 2, 196, 136, 191, 215, 1, 2, 247, 245, 203, 251, 7, 4, 110,
-            3, 109, 123, 110, 120, 1, 0, 1, 1, 32, 246, 145, 242, 105, 221, 102, 170, 79, 196, 78, 105,
-            22, 174, 254, 224, 59, 183, 254, 184, 33, 174, 244, 52, 103, 82, 105, 116, 244, 112, 205,
-            75, 7, 1, 0, 16, 165, 212, 232, 0, 0, 0,
-        ], "[{"archive_module_hash":[[246,145,242,105,221,102,170,79,196,78,105,22,174,254,224,59,183,254,184,33,174,244,52,103,82,105,116,244,112,205,75,7]],"canister_creation_cycles_cost":["1000000000000"]}]")
+    let idl_type = IDLType::OptT(Box::new(IDLType::RecordT(vec![
+        TypeField {
+            label: Label::Named("archive_module_hash".to_string()),
+            typ: IDLType::OptT(Box::new(IDLType::VecT(Box::new(IDLType::PrimT(
+                PrimType::Nat8,
+            ))))),
+        },
+        TypeField {
+            label: Label::Named("assigned_user_number_range".to_string()),
+            typ: IDLType::OptT(IDLType::RecordT([
+                TypeField {
+                    label: Label::Unnamed(0),
+                    typ: IDLType::PrimT(Nat64),
+                },
+                TypeField {
+                    label: Unnamed(1),
+                    typ: PrimT(Nat64),
+                },
+            ])),
+        },
+        TypeField {
+            label: Label::Named("canister_creation_cycles_cost".to_string()),
+            typ: IDLType::OptT(IDLType::PrimT(PrimType::Nat64)),
+        },
+    ])));
+    let binary = &[
+        68, 73, 68, 76, 5, 110, 1, 108, 2, 196, 136, 191, 215, 1, 2, 247, 245, 203, 251, 7, 4, 110,
+        3, 109, 123, 110, 120, 1, 0, 1, 1, 32, 246, 145, 242, 105, 221, 102, 170, 79, 196, 78, 105,
+        22, 174, 254, 224, 59, 183, 254, 184, 33, 174, 244, 52, 103, 82, 105, 116, 244, 112, 205,
+        75, 7, 1, 0, 16, 165, 212, 232, 0, 0, 0,
     ];
+    let expected_json = r#"[{"archive_module_hash":[[246,145,242,105,221,102,170,79,196,78,105,22,174,254,224,59,183,254,184,33,174,244,52,103,82,105,116,244,112,205,75,7]],"canister_creation_cycles_cost":["1000000000000"]}]"#;
 }
-*/

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -1,6 +1,7 @@
 #![warn(missing_docs)]
 #![deny(clippy::panic)]
 #![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
 use candid::parser::{
     types::{IDLType, TypeField},
     value::{IDLField, IDLValue},
@@ -14,6 +15,9 @@ use crate::idl2json;
 /// - Key names MAY be incorrect.  They are provided on a best-effort basis.
 /// - If types are incompatible with the data, the data wins.
 /// - Data is never omitted.
+/// - Fields are never added, even if the schema suggests that some fields are missing.
+/// 
+/// The data is preserved at all cost, the schema is applied only to make the data easier to understand and use.
 pub fn idl2json_with_weak_names(idl: &IDLValue, idl_type: &IDLType) -> JsonValue {
     match (idl, idl_type) {
         (IDLValue::Bool(bool), _) => JsonValue::Bool(*bool),

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -16,7 +16,7 @@ use crate::idl2json;
 /// - If types are incompatible with the data, the data wins.
 /// - Data is never omitted.
 /// - Fields are never added, even if the schema suggests that some fields are missing.
-/// 
+///
 /// The data is preserved at all cost, the schema is applied only to make the data easier to understand and use.
 pub fn idl2json_with_weak_names(idl: &IDLValue, idl_type: &IDLType) -> JsonValue {
     match (idl, idl_type) {
@@ -24,9 +24,9 @@ pub fn idl2json_with_weak_names(idl: &IDLValue, idl_type: &IDLType) -> JsonValue
         (IDLValue::Null, _) => JsonValue::Null,
         (IDLValue::Text(s), _) => JsonValue::String(s.clone()),
         (IDLValue::Number(s), _) => JsonValue::String(s.clone()), // Unspecified number type
-        (IDLValue::Float64(f), _) => {
-            JsonValue::Number(serde_json::Number::from_f64(*f).expect("A float's a float"))
-        }
+        (IDLValue::Float64(f), _) => serde_json::Number::from_f64(*f)
+            .map(JsonValue::Number)
+            .unwrap_or_else(|| JsonValue::String("NaN".to_string())),
         (IDLValue::Opt(value), IDLType::OptT(opt_type)) => {
             JsonValue::Array(vec![idl2json_with_weak_names(value, opt_type)])
         }

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -41,12 +41,12 @@ pub fn idl2json_with_weak_names(idl: &IDLValue, idl_type: &IDLType) -> JsonValue
                 .collect(),
         ),
         (IDLValue::Record(_value), _) => idl2json(idl), // Fallback for mismatched types
-        (IDLValue::Variant(field, _), IDLType::VariantT(record_types)) => JsonValue::Object(
-            vec![convert_idl_field(field, record_types)]
+        (IDLValue::Variant(field), IDLType::VariantT(record_types)) => JsonValue::Object(
+            vec![convert_idl_field(&field.0, record_types)]
                 .into_iter()
                 .collect(),
         ),
-        (IDLValue::Variant(_field, _), _) => idl2json(idl), // Fallback for mismatched types
+        (IDLValue::Variant(_field), _) => idl2json(idl), // Fallback for mismatched types
         (IDLValue::Principal(p), _) => JsonValue::String(p.to_string()),
         (IDLValue::Service(p), _) => JsonValue::String(p.to_string()),
         (IDLValue::Func(p, c), _) => JsonValue::Object(

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -1,0 +1,94 @@
+use candid::{
+    parser::{
+        types::{IDLType, TypeField},
+        value::{IDLField, IDLValue},
+    },
+};
+use serde_json::value::Value as JsonValue;
+
+use crate::idl2json;
+
+/// Converts a candid IDLValue to a serde JsonValue, with keys as names where possible.
+///
+/// - Key names MAY be incorrect.  They are provided on a best-effort basis.
+/// - If types are incompatible with the data, the data wins.
+/// - Data is never omitted.
+pub fn idl2json_with_weak_names(idl: &IDLValue, idl_type: &IDLType) -> JsonValue {
+    match (idl, idl_type) {
+        (IDLValue::Bool(bool), _) => JsonValue::Bool(*bool),
+        (IDLValue::Null, _) => JsonValue::Null,
+        (IDLValue::Text(s), _) => JsonValue::String(s.clone()),
+        (IDLValue::Number(s), _) => JsonValue::String(s.clone()), // Unspecified number type
+        (IDLValue::Float64(f), _) => {
+            JsonValue::Number(serde_json::Number::from_f64(*f).expect("A float's a float"))
+        }
+        (IDLValue::Opt(value), IDLType::OptT(opt_type)) => {
+            JsonValue::Array(vec![idl2json_with_weak_names(value, opt_type)])
+        }
+        (IDLValue::Opt(_value), _) => idl2json(idl), // Fallback for mismatched types
+        (IDLValue::Vec(value), IDLType::VecT(item_type)) => JsonValue::Array(
+            value
+                .iter()
+                .map(|item| idl2json_with_weak_names(item, item_type))
+                .collect(),
+        ),
+        (IDLValue::Vec(_value), _) => idl2json(idl), // Fallback for mismatched types
+        (IDLValue::Record(value), IDLType::RecordT(record_types)) => JsonValue::Object(
+            value
+                .iter()
+                .map(|field| convert_idl_field(field, record_types)).collect(),
+        ),
+        (IDLValue::Record(_value), _) => idl2json(idl), // Fallback for mismatched types
+        (IDLValue::Variant(field, _), IDLType::VariantT(record_types)) => JsonValue::Object(
+            vec![convert_idl_field(field, record_types)]
+                .into_iter()
+                .collect(),
+        ),
+        (IDLValue::Variant(_field, _), _) => idl2json(idl), // Fallback for mismatched types
+        (IDLValue::Principal(p), _) => JsonValue::String(p.to_string()),
+        (IDLValue::Service(p), _) => JsonValue::String(p.to_string()),
+        (IDLValue::Func(p, c), _) => JsonValue::Object(
+            vec![
+                ("principal".to_string(), JsonValue::String(p.to_string())),
+                ("code".to_string(), JsonValue::String(c.to_string())),
+            ]
+            .into_iter()
+            .collect(),
+        ),
+        (IDLValue::None, _) => JsonValue::Array(vec![]),
+        (IDLValue::Int(i), _) => JsonValue::String(i.to_string()),
+        (IDLValue::Nat(i), _) => JsonValue::String(i.to_string()),
+        (IDLValue::Nat8(i), _) => JsonValue::Number(serde_json::Number::from(*i)),
+        (IDLValue::Nat16(i), _) => JsonValue::Number(serde_json::Number::from(*i)),
+        (IDLValue::Nat32(i), _) => JsonValue::Number(serde_json::Number::from(*i)),
+        (IDLValue::Nat64(i), _) => JsonValue::String(i.to_string()),
+        (IDLValue::Int8(i), _) => JsonValue::Number(serde_json::Number::from(*i)),
+        (IDLValue::Int16(i), _) => JsonValue::Number(serde_json::Number::from(*i)),
+        (IDLValue::Int32(i), _) => JsonValue::Number(serde_json::Number::from(*i)),
+        (IDLValue::Int64(i), _) => JsonValue::String(i.to_string()),
+        (IDLValue::Float32(f), _) => {
+            // As far as I can see, JsonValue does not have an explicit NaN type so we provide NaN as a string.
+            serde_json::Number::from_f64(*f as f64).map(JsonValue::Number).unwrap_or_else(|| JsonValue::String("NaN".to_string()))
+        }
+        (IDLValue::Reserved, _) => panic!("Unimplemented: {:?}", idl),
+    }
+}
+
+/// Returns a typed IDLField as a (key, value) pair.
+/// 
+/// - The key is obtained from the type, if possible, else is the raw key as given.
+/// - The value is a typed conversion, if the type is as specified, else it is converted without the benefit of type information.
+fn convert_idl_field(field: &IDLField, record_types: &[TypeField]) -> (String, JsonValue) {
+    let field_id = field.id.get_id();
+    let field_type = record_types
+        .iter()
+        .find(|field_type| field_type.label.get_id() == field_id);
+    field_type
+        .map(|field_type| {
+            (   
+                field_type.label.to_string(),
+                idl2json_with_weak_names(&field.val, &field_type.typ),
+            )
+        })
+        .unwrap_or_else(|| (field.id.to_string(), idl2json(&field.val)))
+}

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -1,11 +1,9 @@
 #![warn(missing_docs)]
 #![deny(clippy::panic)]
 #![deny(clippy::unwrap_used)]
-use candid::{
-    parser::{
-        types::{IDLType, TypeField},
-        value::{IDLField, IDLValue},
-    },
+use candid::parser::{
+    types::{IDLType, TypeField},
+    value::{IDLField, IDLValue},
 };
 use serde_json::value::Value as JsonValue;
 
@@ -39,7 +37,8 @@ pub fn idl2json_with_weak_names(idl: &IDLValue, idl_type: &IDLType) -> JsonValue
         (IDLValue::Record(value), IDLType::RecordT(record_types)) => JsonValue::Object(
             value
                 .iter()
-                .map(|field| convert_idl_field(field, record_types)).collect(),
+                .map(|field| convert_idl_field(field, record_types))
+                .collect(),
         ),
         (IDLValue::Record(_value), _) => idl2json(idl), // Fallback for mismatched types
         (IDLValue::Variant(field, _), IDLType::VariantT(record_types)) => JsonValue::Object(
@@ -71,14 +70,16 @@ pub fn idl2json_with_weak_names(idl: &IDLValue, idl_type: &IDLType) -> JsonValue
         (IDLValue::Int64(i), _) => JsonValue::String(i.to_string()),
         (IDLValue::Float32(f), _) => {
             // As far as I can see, JsonValue does not have an explicit NaN type so we provide NaN as a string.
-            serde_json::Number::from_f64(*f as f64).map(JsonValue::Number).unwrap_or_else(|| JsonValue::String("NaN".to_string()))
+            serde_json::Number::from_f64(*f as f64)
+                .map(JsonValue::Number)
+                .unwrap_or_else(|| JsonValue::String("NaN".to_string()))
         }
         (IDLValue::Reserved, _) => JsonValue::String(idl.to_string()),
     }
 }
 
 /// Returns a typed IDLField as a (key, value) pair.
-/// 
+///
 /// - The key is obtained from the type, if possible, else is the raw key as given.
 /// - The value is a typed conversion, if the type is as specified, else it is converted without the benefit of type information.
 fn convert_idl_field(field: &IDLField, record_types: &[TypeField]) -> (String, JsonValue) {
@@ -88,7 +89,7 @@ fn convert_idl_field(field: &IDLField, record_types: &[TypeField]) -> (String, J
         .find(|field_type| field_type.label.get_id() == field_id);
     field_type
         .map(|field_type| {
-            (   
+            (
                 field_type.label.to_string(),
                 idl2json_with_weak_names(&field.val, &field_type.typ),
             )

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![deny(clippy::panic)]
+#![deny(clippy::unwrap_used)]
 use candid::{
     parser::{
         types::{IDLType, TypeField},
@@ -70,7 +73,7 @@ pub fn idl2json_with_weak_names(idl: &IDLValue, idl_type: &IDLType) -> JsonValue
             // As far as I can see, JsonValue does not have an explicit NaN type so we provide NaN as a string.
             serde_json::Number::from_f64(*f as f64).map(JsonValue::Number).unwrap_or_else(|| JsonValue::String("NaN".to_string()))
         }
-        (IDLValue::Reserved, _) => panic!("Unimplemented: {:?}", idl),
+        (IDLValue::Reserved, _) => JsonValue::String(idl.to_string()),
     }
 }
 

--- a/src/idl2json/src/untyped_conversion.rs
+++ b/src/idl2json/src/untyped_conversion.rs
@@ -19,8 +19,8 @@ pub fn idl2json(idl: &IDLValue) -> JsonValue {
                 .map(|field| (format!("{}", field.id), idl2json(&field.val)))
                 .collect(),
         ),
-        IDLValue::Variant(field, _) => JsonValue::Object(
-            vec![(format!("{}", field.id), idl2json(&field.val))]
+        IDLValue::Variant(field) => JsonValue::Object(
+            vec![(format!("{}", field.0.id), idl2json(&field.0.val))]
                 .into_iter()
                 .collect(),
         ),

--- a/src/idl2json/src/untyped_conversion.rs
+++ b/src/idl2json/src/untyped_conversion.rs
@@ -1,0 +1,53 @@
+use candid::parser::value::IDLValue;
+use serde_json::value::Value as JsonValue;
+
+/// Converts a candid IDLValue to a serde JsonValue, without type information.
+pub fn idl2json(idl: &IDLValue) -> JsonValue {
+    match idl {
+        IDLValue::Bool(bool) => JsonValue::Bool(*bool),
+        IDLValue::Null => JsonValue::Null,
+        IDLValue::Text(s) => JsonValue::String(s.clone()),
+        IDLValue::Number(s) => JsonValue::String(s.clone()), // Unspecified number type
+        IDLValue::Float64(f) => {
+            JsonValue::Number(serde_json::Number::from_f64(*f).expect("A float's a float"))
+        }
+        IDLValue::Opt(value) => JsonValue::Array(vec![idl2json(value)]),
+        IDLValue::Vec(value) => JsonValue::Array(value.iter().map(idl2json).collect()),
+        IDLValue::Record(value) => JsonValue::Object(
+            value
+                .iter()
+                .map(|field| (format!("{}", field.id), idl2json(&field.val)))
+                .collect(),
+        ),
+        IDLValue::Variant(field, _) => JsonValue::Object(
+            vec![(format!("{}", field.id), idl2json(&field.val))]
+                .into_iter()
+                .collect(),
+        ),
+        IDLValue::Principal(p) => JsonValue::String(format!("{}", p)),
+        IDLValue::Service(p) => JsonValue::String(format!("{}", p)),
+        IDLValue::Func(p, c) => JsonValue::Object(
+            vec![
+                ("principal".to_string(), JsonValue::String(format!("{}", p))),
+                ("code".to_string(), JsonValue::String(c.to_string())),
+            ]
+            .into_iter()
+            .collect(),
+        ),
+        IDLValue::None => JsonValue::Array(vec![]),
+        IDLValue::Int(i) => JsonValue::String(format!("{}", i)),
+        IDLValue::Nat(i) => JsonValue::String(format!("{}", i)),
+        IDLValue::Nat8(i) => JsonValue::Number(serde_json::Number::from(*i)),
+        IDLValue::Nat16(i) => JsonValue::Number(serde_json::Number::from(*i)),
+        IDLValue::Nat32(i) => JsonValue::Number(serde_json::Number::from(*i)),
+        IDLValue::Nat64(i) => JsonValue::String(format!("{}", i)),
+        IDLValue::Int8(i) => JsonValue::Number(serde_json::Number::from(*i)),
+        IDLValue::Int16(i) => JsonValue::Number(serde_json::Number::from(*i)),
+        IDLValue::Int32(i) => JsonValue::Number(serde_json::Number::from(*i)),
+        IDLValue::Int64(i) => JsonValue::String(format!("{}", i)),
+        IDLValue::Float32(f) => {
+            JsonValue::Number(serde_json::Number::from_f64(*f as f64).expect("A float's a float"))
+        }
+        IDLValue::Reserved => panic!("Unimplemented: {:?}", idl),
+    }
+}

--- a/src/idl2json_cli/Cargo.toml
+++ b/src/idl2json_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idl2json_cli"
-version = "0.8.4"
+version = "0.8.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,6 +10,6 @@ name = "idl2json"
 path = "src/main.rs"
 
 [dependencies]
-candid = "0.8.4" # Should match the version in the lib.
+candid = "0.8.1" # Should match the version in the lib.
 serde_json = "^1.0"
 idl2json = { path = "../idl2json" }

--- a/src/idl2json_cli/Cargo.toml
+++ b/src/idl2json_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idl2json_cli"
-version = "0.1.0"
+version = "0.8.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,6 +10,6 @@ name = "idl2json"
 path = "src/main.rs"
 
 [dependencies]
-candid = "0.6.21"
+candid = "0.8.4" # Should match the version in the lib.
 serde_json = "^1.0"
 idl2json = { path = "../idl2json" }


### PR DESCRIPTION
# Motivation
It would be nice to have type names in records and variants.  If a did file is available, this can be done on a best-effort basis.

# Changes
- Bump the candid version to 0.8.1
- Move the untyped idl2json to another file in the library
- Add a typed idl2json to the library
- Add an example to illustrate how the typed conversion works, printing intermediate values.
- Add a `rust_toolchain.toml` as the code doesn't compile with whatever Rust I was using at first.
- Added clippy lints to ensure that the code cannot panic with `panic()`, `unwrap()` or `expect()`.  The conversion should never fail.
- Added a function to convert internal types to IDLTypes, because `#[derive(Candid)]` provides the internal type.

# Tests
- Added a single "happy path" test for decoding binary candid to JSON with a given schema.
- The same test is repeated with derived type information.