### PR TITLE
feat: Add support for schemas on the command line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
+name = "fn-error-context"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "236b4e4ae2b8be5f7a5652f6108c4a0f2627c569db4e7923333d31c7dbfed0fb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,8 +642,10 @@ dependencies = [
 name = "idl2json_cli"
 version = "0.8.5"
 dependencies = [
+ "anyhow",
  "candid 0.8.4",
  "clap",
+ "fn-error-context",
  "idl2json",
  "serde_json",
  "toml",

--- a/src/idl2json/examples/init.rs
+++ b/src/idl2json/examples/init.rs
@@ -6,7 +6,7 @@ use candid::{
     },
     Decode, IDLProg,
 };
-use idl2json::{idl2json, idl2json_with_weak_names, Idl2JsonOptions};
+use idl2json::{idl2json, idl2json_with_weak_names, polyfill, Idl2JsonOptions};
 use std::str::FromStr;
 
 /// Converts some sample candid bytes to JSON using a .did file.
@@ -20,18 +20,7 @@ fn main() {
     // TODO: This is still unimplemented in candid, but should be available soon.
     //let rust = idl_to_rust(&prog, &Config::default()).expect("Could not compute rust");
     //println!("Rust: {rust}");
-    let idl_type = prog
-        .decs
-        .iter()
-        .find_map(|x| {
-            if let Dec::TypD(y) = x {
-                if y.id == type_name {
-                    return Some(y.typ.clone());
-                }
-            }
-            None
-        })
-        .expect("Failed to get idltype");
+    let idl_type = polyfill::idl_prog::get(&prog, type_name).expect("Failed to get idltype");
     let idl_type = IDLType::OptT(Box::new(idl_type));
     println!("Type: {:?}\n\n", &idl_type);
     let buffer = [

--- a/src/idl2json/src/lib.rs
+++ b/src/idl2json/src/lib.rs
@@ -7,6 +7,7 @@
 
 mod bytes;
 pub mod candid_types;
+pub mod polyfill;
 mod typed_conversion;
 mod untyped_conversion;
 

--- a/src/idl2json/src/polyfill.rs
+++ b/src/idl2json/src/polyfill.rs
@@ -1,0 +1,21 @@
+//! Code that should be pushed upstream.
+
+/// Polyfills for the candid IDLProg struct.
+pub mod idl_prog {
+    use candid::{
+        parser::types::{Dec, IDLType},
+        IDLProg,
+    };
+
+    /// Polyfill for IDLProg.get(key)
+    pub fn get(prog: &IDLProg, key: &str) -> Option<IDLType> {
+        prog.decs.iter().find_map(|x| {
+            if let Dec::TypD(y) = x {
+                if y.id == key {
+                    return Some(y.typ.clone());
+                }
+            }
+            None
+        })
+    }
+}

--- a/src/idl2json_cli/Cargo.toml
+++ b/src/idl2json_cli/Cargo.toml
@@ -12,8 +12,10 @@ path = "src/main.rs"
 [dependencies]
 candid = "0.8.1" # Should match the version in the lib.
 clap = { version = "3.1.6", features = [ "derive" ] }
+fn-error-context = "0.2.0"
 serde_json = "^1.0"
 idl2json = { path = "../idl2json" }
+anyhow = "1"
 
 [build-dependencies]
 toml = "0.5.9"

--- a/src/idl2json_cli/src/lib.rs
+++ b/src/idl2json_cli/src/lib.rs
@@ -1,20 +1,49 @@
-use candid::IDLArgs;
+use anyhow::{anyhow, Context};
+use candid::{parser::types::IDLType, IDLArgs, IDLProg};
 use clap::Parser;
-use idl2json::{idl2json, Idl2JsonOptions};
-use std::io::{self, Read};
+use idl2json::{idl2json, idl2json_with_weak_names, polyfill, Idl2JsonOptions};
+use std::{
+    io::{self, Read},
+    path::PathBuf,
+    str::FromStr,
+};
 
 /// Reads IDL from stdin, writes JSON to stdout.
-pub fn main() -> io::Result<()> {
-    let _args = Args::parse();
+pub fn main(args: &Args) -> anyhow::Result<()> {
+    let idl_args = {
+        let mut buffer = String::new();
+        io::stdin()
+            .read_to_string(&mut buffer)
+            .with_context(|| anyhow!("Failed to read string from stdin"))?;
+        let idl_args: IDLArgs = buffer.parse().expect("Malformed input");
+        idl_args
+    };
+    let idl_value = idl_args
+        .args
+        .get(0)
+        .ok_or_else(|| anyhow!("No value in input"))?;
 
-    let mut buffer = String::new();
-    io::stdin().read_to_string(&mut buffer)?;
+    let idl2json_options = Idl2JsonOptions::default();
 
-    let idl_args: IDLArgs = buffer.parse().expect("Malformed input");
+    let json_value = if let (Some(did), Some(typ)) = (&args.did, &args.typ) {
+        let idl_type: IDLType = {
+            let prog = {
+                let did_as_str = std::fs::read_to_string(&did)
+                    .with_context(|| anyhow!("Could not read did file '{}'.", did.display()))?;
+                IDLProg::from_str(&did_as_str)
+                    .with_context(|| anyhow!("Failed to parse did file '{}'", did.display()))?
+            };
+            polyfill::idl_prog::get(&prog, typ).ok_or_else(|| {
+                anyhow!("Type '{typ}' not found in .did file '{}'.", did.display())
+            })?
+        };
+        idl2json_with_weak_names(idl_value, &idl_type, &idl2json_options)
+    } else {
+        idl2json(idl_value, &idl2json_options)
+    };
     println!(
         "{}",
-        serde_json::to_string(&idl2json(&idl_args.args[0], &Idl2JsonOptions::default()))
-            .expect("Cannot get it out")
+        serde_json::to_string(&json_value).expect("Cannot get it out")
     );
 
     Ok(())
@@ -23,4 +52,11 @@ pub fn main() -> io::Result<()> {
 /// Converts Candid on stdin to JSON on stdout.
 #[derive(Parser, Debug)]
 #[clap(name("idl2json"), version = concat!(env!("CARGO_PKG_VERSION"), "\ncandid ", env!("CARGO_CANDID_VERSION")))]
-struct Args {}
+pub struct Args {
+    /// A .did file containing type definitions
+    #[clap(short, long)]
+    did: Option<PathBuf>,
+    /// The name of a type in the provided .did file
+    #[clap(short, long)]
+    typ: Option<String>,
+}

--- a/src/idl2json_cli/src/lib.rs
+++ b/src/idl2json_cli/src/lib.rs
@@ -1,3 +1,10 @@
+//! Command line library for converting candid to JSON.
+#![warn(missing_docs)]
+#![deny(clippy::panic)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+#![deny(clippy::unimplemented)]
+
 use anyhow::{anyhow, Context};
 use candid::{parser::types::IDLType, IDLArgs, IDLProg};
 use clap::Parser;
@@ -15,7 +22,7 @@ pub fn main(args: &Args) -> anyhow::Result<()> {
         io::stdin()
             .read_to_string(&mut buffer)
             .with_context(|| anyhow!("Failed to read string from stdin"))?;
-        let idl_args: IDLArgs = buffer.parse().expect("Malformed input");
+        let idl_args: IDLArgs = buffer.parse().with_context(|| anyhow!("Malformed input"))?;
         idl_args
     };
     let idl_value = idl_args
@@ -43,7 +50,7 @@ pub fn main(args: &Args) -> anyhow::Result<()> {
     };
     println!(
         "{}",
-        serde_json::to_string(&json_value).expect("Cannot get it out")
+        serde_json::to_string(&json_value).with_context(|| anyhow!("Cannot print to stderr"))?
     );
 
     Ok(())

--- a/src/idl2json_cli/src/lib.rs
+++ b/src/idl2json_cli/src/lib.rs
@@ -35,7 +35,7 @@ pub fn main(args: &Args) -> anyhow::Result<()> {
     let json_value = if let (Some(did), Some(typ)) = (&args.did, &args.typ) {
         let idl_type: IDLType = {
             let prog = {
-                let did_as_str = std::fs::read_to_string(&did)
+                let did_as_str = std::fs::read_to_string(did)
                     .with_context(|| anyhow!("Could not read did file '{}'.", did.display()))?;
                 IDLProg::from_str(&did_as_str)
                     .with_context(|| anyhow!("Failed to parse did file '{}'", did.display()))?

--- a/src/idl2json_cli/src/main.rs
+++ b/src/idl2json_cli/src/main.rs
@@ -1,6 +1,8 @@
+use clap::Parser;
 use idl2json_cli as lib;
 
 /// Reads IDL from stdin, writes JSON to stdout.
 fn main() {
-    lib::main().expect("Failed to convert IDL to JSON");
+    let args = lib::Args::parse();
+    lib::main(&args).expect("Failed to convert IDL to JSON");
 }


### PR DESCRIPTION
# Motivation
The idl2json library supports converting data with the help of a schema.  This is now also supported on the command line.

Note that a further chnage is needed for this to become really useful:  idl2json needs to support binary input.

# Changes
- Factor out the IDLProg getter function into a file of polyfills.
- Add flags to allow the user to specify a type and did file
- Use types when converting, if available