### PR TITLE
fix: Support vector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "idl2json"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "candid 0.8.4",
  "json-patch",
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "idl2json_cli"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "candid 0.8.4",
@@ -1599,7 +1599,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "yaml2candid"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "candid 0.7.0",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "yaml2candid_cli"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "clap",
  "toml",

--- a/src/idl2json/Cargo.toml
+++ b/src/idl2json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idl2json"
-version = "0.8.5"
+version = "0.8.6"
 authors = ["dfinity <sdk@dfinity.org>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/idl2json/examples/init.rs
+++ b/src/idl2json/examples/init.rs
@@ -1,7 +1,7 @@
 //! Example of how to convert binary candid to JSON using a schema
 use candid::{
     parser::{
-        types::{Dec, IDLType},
+        types::{IDLType},
         value::IDLValue,
     },
     Decode, IDLProg,

--- a/src/idl2json/examples/init.rs
+++ b/src/idl2json/examples/init.rs
@@ -1,9 +1,6 @@
 //! Example of how to convert binary candid to JSON using a schema
 use candid::{
-    parser::{
-        types::{IDLType},
-        value::IDLValue,
-    },
+    parser::{types::IDLType, value::IDLValue},
     Decode, IDLProg,
 };
 use idl2json::{idl2json, idl2json_with_weak_names, polyfill, Idl2JsonOptions};

--- a/src/idl2json/src/lib.rs
+++ b/src/idl2json/src/lib.rs
@@ -27,9 +27,10 @@ pub struct Idl2JsonOptions {
 }
 
 /// Options for how to represent `Vec<u8>`
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Default)]
 pub enum BytesFormat {
     /// Data is represented as an array of numbers: `[1,34,0]`
+    #[default]
     Numbers,
     /// Data is represented as hex: `"A4B7"`
     Hex,
@@ -39,10 +40,4 @@ pub enum BytesFormat {
     #[cfg(feature = "crypto")]
     /// Data is hashed:  "sha512:abbabababababababbababababab"
     Sha256,
-}
-
-impl Default for BytesFormat {
-    fn default() -> Self {
-        BytesFormat::Numbers
-    }
 }

--- a/src/idl2json_cli/Cargo.toml
+++ b/src/idl2json_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idl2json_cli"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/idl2json_cli/src/lib.rs
+++ b/src/idl2json_cli/src/lib.rs
@@ -9,38 +9,43 @@ use anyhow::{anyhow, Context};
 use candid::{parser::types::IDLType, IDLArgs, IDLProg};
 use clap::Parser;
 use idl2json::{idl2json, idl2json_with_weak_names, polyfill, Idl2JsonOptions};
-use std::{
-    path::PathBuf,
-    str::FromStr,
-};
+use std::{path::PathBuf, str::FromStr};
 
 /// Reads IDL from stdin, writes JSON to stdout.
 pub fn main(args: &Args, idl_str: &str) -> anyhow::Result<String> {
     let idl_args = {
-        let idl_args: IDLArgs = idl_str.parse().with_context(|| anyhow!("Malformed input"))?;
+        let idl_args: IDLArgs = idl_str
+            .parse()
+            .with_context(|| anyhow!("Malformed input"))?;
         idl_args
     };
-    let json_structures: anyhow::Result<Vec<String>> = idl_args.args.iter().map(|idl_value| {
-        let idl2json_options = Idl2JsonOptions::default();
+    let json_structures: anyhow::Result<Vec<String>> = idl_args
+        .args
+        .iter()
+        .map(|idl_value| {
+            let idl2json_options = Idl2JsonOptions::default();
 
-        let json_value = if let (Some(did), Some(typ)) = (&args.did, &args.typ) {
-            let idl_type: IDLType = {
-                let prog = {
-                    let did_as_str = std::fs::read_to_string(did)
-                        .with_context(|| anyhow!("Could not read did file '{}'.", did.display()))?;
-                    IDLProg::from_str(&did_as_str)
-                        .with_context(|| anyhow!("Failed to parse did file '{}'", did.display()))?
+            let json_value = if let (Some(did), Some(typ)) = (&args.did, &args.typ) {
+                let idl_type: IDLType = {
+                    let prog = {
+                        let did_as_str = std::fs::read_to_string(did).with_context(|| {
+                            anyhow!("Could not read did file '{}'.", did.display())
+                        })?;
+                        IDLProg::from_str(&did_as_str).with_context(|| {
+                            anyhow!("Failed to parse did file '{}'", did.display())
+                        })?
+                    };
+                    polyfill::idl_prog::get(&prog, typ).ok_or_else(|| {
+                        anyhow!("Type '{typ}' not found in .did file '{}'.", did.display())
+                    })?
                 };
-                polyfill::idl_prog::get(&prog, typ).ok_or_else(|| {
-                    anyhow!("Type '{typ}' not found in .did file '{}'.", did.display())
-                })?
+                idl2json_with_weak_names(&idl_value, &idl_type, &idl2json_options)
+            } else {
+                idl2json(&idl_value, &idl2json_options)
             };
-            idl2json_with_weak_names(&idl_value, &idl_type, &idl2json_options)
-        } else {
-            idl2json(&idl_value, &idl2json_options)
-        };
-        serde_json::to_string(&json_value).with_context(|| anyhow!("Cannot print to stderr"))
-    }).collect();
+            serde_json::to_string(&json_value).with_context(|| anyhow!("Cannot print to stderr"))
+        })
+        .collect();
     Ok(json_structures?.join("\n"))
 }
 

--- a/src/idl2json_cli/src/lib.rs
+++ b/src/idl2json_cli/src/lib.rs
@@ -39,9 +39,9 @@ pub fn main(args: &Args, idl_str: &str) -> anyhow::Result<String> {
                         anyhow!("Type '{typ}' not found in .did file '{}'.", did.display())
                     })?
                 };
-                idl2json_with_weak_names(&idl_value, &idl_type, &idl2json_options)
+                idl2json_with_weak_names(idl_value, &idl_type, &idl2json_options)
             } else {
-                idl2json(&idl_value, &idl2json_options)
+                idl2json(idl_value, &idl2json_options)
             };
             serde_json::to_string(&json_value).with_context(|| anyhow!("Cannot print to stderr"))
         })

--- a/src/idl2json_cli/src/main.rs
+++ b/src/idl2json_cli/src/main.rs
@@ -1,8 +1,14 @@
 use clap::Parser;
 use idl2json_cli as lib;
+use std::io::{self, Read};
 
 /// Reads IDL from stdin, writes JSON to stdout.
 fn main() {
     let args = lib::Args::parse();
-    lib::main(&args).expect("Failed to convert IDL to JSON");
+    let mut buffer = String::new();
+    io::stdin()
+        .read_to_string(&mut buffer)
+        .expect("Failed to read string from stdin");
+    let json_str = lib::main(&args, &buffer).expect("Failed to convert IDL to JSON");
+    println!("{json_str}");
 }

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -9,6 +9,8 @@ fn simple_conversion_should_be_correct() {
    let args = Args::default();
     let vectors = [
      TestVector{ stdin: "()", stdout: "\n" }
+     TestVector{ stdin: "( record {} )", stdout: "{}\n" }
+     TestVector{ stdin: "( record {}, record {} )", stdout: "{}\n{}\n" }
   ];
   for vector in vectors {
       let out = main(&args, vector.stdin).map_err(|e| anyhow!("Failed to parse: {} due to: {e}", vector.stdin)).unwrap();

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -1,0 +1,17 @@
+use super::{main, Args};
+use anyhow::{anyhow, Context};
+
+#[test]
+fn simple_conversion_should_be_correct() {
+   struct TestVector {
+     stdin: &'static str, stdout: &'static str
+   }
+   let args = Args::default();
+    let vectors = [
+     TestVector{ stdin: "()", stdout: "\n" }
+  ];
+  for vector in vectors {
+      let out = main(&args, vector.stdin).map_err(|e| anyhow!("Failed to parse: {} due to: {e}", vector.stdin)).unwrap();
+    assert_eq!(vector.stdout, &out)
+  }
+}

--- a/src/yaml2candid/Cargo.toml
+++ b/src/yaml2candid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaml2candid"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/yaml2candid_cli/Cargo.toml
+++ b/src/yaml2candid_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaml2candid_cli"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
# Motivation
The idl2json command line assumes the common case of a single candid structure:
```
$ echo "( record {} )" | idl2json 
{}
```
however there may be multiple or no structures.  This is currently unsupported.  Effectively this means that the output becomes an array with zero or more entries.  This can be done without breaking backwards compatibility by emitting zero or more JSON structures:
```
$ echo "()" | idl2json 
$ echo "( record {} )" | idl2json 
{}
$ echo "( record {}, record {} )" | ./target/debug/idl2json 
{}
{}
```
# Changes
- Support an arbitrary number of `IDLValue`s
- Refactor to take a string as input and output of the main library function, to make it testable.
- Add tests
- Bump the cargo version
- Address clippy issues in the existing code