### PR TITLE
Cleanup idl2json main

### DIFF
--- a/src/idl2json_cli/src/lib.rs
+++ b/src/idl2json_cli/src/lib.rs
@@ -6,6 +6,7 @@
 #![deny(clippy::unimplemented)]
 
 use anyhow::{anyhow, Context};
+use candid::parser::value::IDLValue;
 use candid::{parser::types::IDLType, IDLArgs, IDLProg};
 use clap::Parser;
 use idl2json::{idl2json, idl2json_with_weak_names, polyfill, Idl2JsonOptions};
@@ -13,38 +14,48 @@ use std::{path::PathBuf, str::FromStr};
 
 /// Reads IDL from stdin, writes JSON to stdout.
 pub fn main(args: &Args, idl_str: &str) -> anyhow::Result<String> {
-    let idl_args = {
-        let idl_args: IDLArgs = idl_str
-            .parse()
-            .with_context(|| anyhow!("Malformed input"))?;
-        idl_args
+    let idl_args: IDLArgs = idl_str
+        .parse()
+        .with_context(|| anyhow!("Malformed input"))?;
+    let idl2json_options = Idl2JsonOptions::default();
+    convert_all(&idl_args, args, &idl2json_options)
+}
+
+/// Candid typically comes as a tuple of values.  This converts a single value in such a tuple.
+fn convert_one(
+    idl_value: &IDLValue,
+    args: &Args,
+    idl2json_options: &Idl2JsonOptions,
+) -> anyhow::Result<String> {
+    let json_value = if let (Some(did), Some(typ)) = (&args.did, &args.typ) {
+        let idl_type: IDLType = {
+            let prog = {
+                let did_as_str = std::fs::read_to_string(did)
+                    .with_context(|| anyhow!("Could not read did file '{}'.", did.display()))?;
+                IDLProg::from_str(&did_as_str)
+                    .with_context(|| anyhow!("Failed to parse did file '{}'", did.display()))?
+            };
+            polyfill::idl_prog::get(&prog, typ).ok_or_else(|| {
+                anyhow!("Type '{typ}' not found in .did file '{}'.", did.display())
+            })?
+        };
+        idl2json_with_weak_names(idl_value, &idl_type, idl2json_options)
+    } else {
+        idl2json(idl_value, idl2json_options)
     };
+    serde_json::to_string(&json_value).with_context(|| anyhow!("Cannot print to stderr"))
+}
+
+/// Candid typically comes as a tuple of values.  This converts all such tuples
+fn convert_all(
+    idl_args: &IDLArgs,
+    args: &Args,
+    idl2json_options: &Idl2JsonOptions,
+) -> anyhow::Result<String> {
     let json_structures: anyhow::Result<Vec<String>> = idl_args
         .args
         .iter()
-        .map(|idl_value| {
-            let idl2json_options = Idl2JsonOptions::default();
-
-            let json_value = if let (Some(did), Some(typ)) = (&args.did, &args.typ) {
-                let idl_type: IDLType = {
-                    let prog = {
-                        let did_as_str = std::fs::read_to_string(did).with_context(|| {
-                            anyhow!("Could not read did file '{}'.", did.display())
-                        })?;
-                        IDLProg::from_str(&did_as_str).with_context(|| {
-                            anyhow!("Failed to parse did file '{}'", did.display())
-                        })?
-                    };
-                    polyfill::idl_prog::get(&prog, typ).ok_or_else(|| {
-                        anyhow!("Type '{typ}' not found in .did file '{}'.", did.display())
-                    })?
-                };
-                idl2json_with_weak_names(idl_value, &idl_type, &idl2json_options)
-            } else {
-                idl2json(idl_value, &idl2json_options)
-            };
-            serde_json::to_string(&json_value).with_context(|| anyhow!("Cannot print to stderr"))
-        })
+        .map(|idl_value| convert_one(idl_value, args, idl2json_options))
         .collect();
     Ok(json_structures?.join("\n"))
 }


### PR DESCRIPTION
# Motivation
The main function in idl2json has become too large.  Also, hiding in that complexity, the code for reading a type was being called once for every IDLValue, which is quite inefficient.

# Changes
- Break the main function into smaller pieces.
- Move code out of loops, where appropriate.

# Tests
There is no change in functionality.  Existing tests should suffice.