### PR TITLE
Parse service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,7 @@ version = "0.8.6"
 dependencies = [
  "candid 0.8.4",
  "json-patch",
+ "num-bigint",
  "serde",
  "serde_json",
  "sha2 0.10.6",

--- a/src/idl2json/Cargo.toml
+++ b/src/idl2json/Cargo.toml
@@ -15,6 +15,7 @@ sha2 = { version = "0.10.6", optional = true }
 [dev-dependencies]
 json-patch = "0.2.6"
 serde = "1"
+num-bigint = "0.4.3"
 
 [features]
 default = ["crypto"]

--- a/src/idl2json/examples/init.rs
+++ b/src/idl2json/examples/init.rs
@@ -17,7 +17,7 @@ fn main() {
     // TODO: This is still unimplemented in candid, but should be available soon.
     //let rust = idl_to_rust(&prog, &Config::default()).expect("Could not compute rust");
     //println!("Rust: {rust}");
-    let idl_type = polyfill::idl_prog::get(&prog, type_name).expect("Failed to get idltype");
+    let idl_type = polyfill::idl_prog::get_type(&prog, type_name).expect("Failed to get idltype");
     let idl_type = IDLType::OptT(Box::new(idl_type));
     println!("Type: {:?}\n\n", &idl_type);
     let buffer = [

--- a/src/idl2json/src/lib.rs
+++ b/src/idl2json/src/lib.rs
@@ -12,7 +12,10 @@ mod typed_conversion;
 mod untyped_conversion;
 
 pub use serde_json::Value as JsonValue;
-pub use typed_conversion::{idl2json_with_weak_names, idl_args2json_with_weak_names};
+pub use typed_conversion::{
+    get_fn_type, get_service_arg, get_type, get_type_from_any, idl2json_with_weak_names,
+    idl_args2json_with_weak_names,
+};
 pub use untyped_conversion::{idl2json, idl_args2json};
 #[cfg(test)]
 mod test;

--- a/src/idl2json/src/lib.rs
+++ b/src/idl2json/src/lib.rs
@@ -11,6 +11,7 @@ pub mod polyfill;
 mod typed_conversion;
 mod untyped_conversion;
 
+use candid::IDLProg;
 pub use serde_json::Value as JsonValue;
 pub use typed_conversion::{
     get_fn_type, get_service_arg, get_type, get_type_from_any, idl2json_with_weak_names,
@@ -21,12 +22,14 @@ pub use untyped_conversion::{idl2json, idl_args2json};
 mod test;
 
 /// Options for idl2json conversions
-#[derive(Default, Clone, Eq, PartialEq)]
+#[derive(Default)]
 pub struct Idl2JsonOptions {
     /// How to represent `Vec<u8>`
     pub bytes_as: Option<BytesFormat>,
     /// How to represent `Vec<u8>` of at least some given length.
     pub long_bytes_as: Option<(usize, BytesFormat)>,
+    /// Type definitions
+    pub prog: Vec<IDLProg>,
 }
 
 /// Options for how to represent `Vec<u8>`

--- a/src/idl2json/src/lib.rs
+++ b/src/idl2json/src/lib.rs
@@ -13,10 +13,7 @@ mod untyped_conversion;
 
 use candid::IDLProg;
 pub use serde_json::Value as JsonValue;
-pub use typed_conversion::{
-    get_fn_type, get_service_arg, get_type, get_type_from_any, idl2json_with_weak_names,
-    idl_args2json_with_weak_names,
-};
+pub use typed_conversion::{idl2json_with_weak_names, idl_args2json_with_weak_names};
 pub use untyped_conversion::{idl2json, idl_args2json};
 #[cfg(test)]
 mod test;

--- a/src/idl2json/src/lib.rs
+++ b/src/idl2json/src/lib.rs
@@ -12,7 +12,7 @@ mod typed_conversion;
 mod untyped_conversion;
 
 pub use serde_json::Value as JsonValue;
-pub use typed_conversion::idl2json_with_weak_names;
+pub use typed_conversion::{idl2json_with_weak_names, idl_args2json_with_weak_names};
 pub use untyped_conversion::{idl2json, idl_args2json};
 #[cfg(test)]
 mod test;

--- a/src/idl2json/src/lib.rs
+++ b/src/idl2json/src/lib.rs
@@ -25,7 +25,16 @@ pub struct Idl2JsonOptions {
     pub bytes_as: Option<BytesFormat>,
     /// How to represent `Vec<u8>` of at least some given length.
     pub long_bytes_as: Option<(usize, BytesFormat)>,
-    /// Type definitions
+    /// Type definitions.
+    ///
+    /// Note:
+    /// - An `IDLProg`  corresponds to a parsed `.did` file.
+    /// - Typically either no `IDLProg` is available or one `IDLProg`
+    ///   is provided, corresponding to the `.did` file of a canister
+    ///   and that one `.did` file has all required definitions.
+    /// - In rare cases, multiple IDLProgs are needed.  If so,
+    ///   `idl2json` will use the first match it finds.  It is the
+    ///   caller's responsibility to ensure that there are no conflicting definitions.
     pub prog: Vec<IDLProg>,
 }
 

--- a/src/idl2json/src/lib.rs
+++ b/src/idl2json/src/lib.rs
@@ -13,7 +13,7 @@ mod untyped_conversion;
 
 pub use serde_json::Value as JsonValue;
 pub use typed_conversion::idl2json_with_weak_names;
-pub use untyped_conversion::idl2json;
+pub use untyped_conversion::{idl2json, idl_args2json};
 #[cfg(test)]
 mod test;
 

--- a/src/idl2json/src/polyfill.rs
+++ b/src/idl2json/src/polyfill.rs
@@ -7,13 +7,13 @@ pub mod idl_prog {
         IDLProg,
     };
 
-    /// Deprecated; please use `get_type(..)` instead.
-    /// TODO: Use the rust deprecated syntax
+    /// Gets a type defined in a program declarations section.
+    #[deprecated(since="0.8.6", note="Please use `get_type()` instead.")]
     pub fn get(prog: &IDLProg, key: &str) -> Option<IDLType> {
         get_type(prog, key)
     }
 
-    /// Gets a type declared in any of the program declaration sections.
+    /// Gets a type defined in a program declarations section.
     pub fn get_type(prog: &IDLProg, key: &str) -> Option<IDLType> {
         prog.decs.iter().find_map(|x| {
             if let Dec::TypD(y) = x {

--- a/src/idl2json/src/polyfill.rs
+++ b/src/idl2json/src/polyfill.rs
@@ -14,7 +14,7 @@ pub mod idl_prog {
     }
 
     /// Gets the type of the service init arg.
-    pub fn get_init_arg_type(prog: &IDLProg, key: &str) -> Option<IDLType> {
+    pub fn get_type(prog: &IDLProg, key: &str) -> Option<IDLType> {
         prog.decs.iter().find_map(|x| {
             if let Dec::TypD(y) = x {
                 if y.id == key {
@@ -25,18 +25,14 @@ pub mod idl_prog {
         })
     }
 
-    /// Gets the arguments for creating a service
-    pub fn get_service_arg(prog: &IDLProg) -> Option<IDLTypes> {
+    /// Gets the arguments for creating a service.
+    ///
+    /// This will return None if the prog contains no service aka actor of type ClassT.
+    pub fn get_init_arg_type(prog: &IDLProg) -> Option<IDLTypes> {
         if let Some(IDLType::ClassT(args, _)) = &prog.actor {
             Some(IDLTypes { args: args.clone() })
         } else {
             None
         }
-    }
-    /// Gets the arguments and return values of a service method.
-    ///
-    /// Note: In a canister .did file there is typically a service section containing these service methods.
-    pub fn get_fn_type(_fn_name: &str, _prog: &IDLProg) -> Option<(IDLTypes, IDLTypes)> {
-        unimplemented!()
     }
 }

--- a/src/idl2json/src/polyfill.rs
+++ b/src/idl2json/src/polyfill.rs
@@ -13,7 +13,7 @@ pub mod idl_prog {
         get_type(prog, key)
     }
 
-    /// Gets the type of the service init arg.
+    /// Gets a type declared in any of the program declaration sections.
     pub fn get_type(prog: &IDLProg, key: &str) -> Option<IDLType> {
         prog.decs.iter().find_map(|x| {
             if let Dec::TypD(y) = x {

--- a/src/idl2json/src/polyfill.rs
+++ b/src/idl2json/src/polyfill.rs
@@ -3,12 +3,18 @@
 /// Polyfills for the candid IDLProg struct.
 pub mod idl_prog {
     use candid::{
-        parser::types::{Dec, IDLType},
+        parser::types::{Dec, IDLType, IDLTypes},
         IDLProg,
     };
 
-    /// Polyfill for IDLProg.get(key)
+    /// Deprecated; please use `get_type(..)` instead.
+    /// TODO: Use the rust deprecated syntax
     pub fn get(prog: &IDLProg, key: &str) -> Option<IDLType> {
+        get_type(prog, key)
+    }
+
+    /// Polyfill for IDLProg.get(key), that gets the type of the given name.
+    pub fn get_type(prog: &IDLProg, key: &str) -> Option<IDLType> {
         prog.decs.iter().find_map(|x| {
             if let Dec::TypD(y) = x {
                 if y.id == key {
@@ -17,5 +23,16 @@ pub mod idl_prog {
             }
             None
         })
+    }
+
+    /// Gets the arguments for creating a service
+    pub fn get_service_arg(_prog: &IDLProg) -> Option<IDLTypes> {
+        unimplemented!()
+    }
+    /// Gets the arguments and return values of a service method.
+    ///
+    /// Note: In a canister .did file there is typically a service section containing these service methods.
+    pub fn get_fn_type(_fn_name: &str, _prog: &IDLProg) -> Option<(IDLTypes, IDLTypes)> {
+        unimplemented!()
     }
 }

--- a/src/idl2json/src/polyfill.rs
+++ b/src/idl2json/src/polyfill.rs
@@ -8,7 +8,7 @@ pub mod idl_prog {
     };
 
     /// Gets a type defined in a program declarations section.
-    #[deprecated(since="0.8.6", note="Please use `get_type()` instead.")]
+    #[deprecated(since = "0.8.6", note = "Please use `get_type()` instead.")]
     pub fn get(prog: &IDLProg, key: &str) -> Option<IDLType> {
         get_type(prog, key)
     }

--- a/src/idl2json/src/polyfill.rs
+++ b/src/idl2json/src/polyfill.rs
@@ -13,8 +13,8 @@ pub mod idl_prog {
         get_type(prog, key)
     }
 
-    /// Polyfill for IDLProg.get(key), that gets the type of the given name.
-    pub fn get_type(prog: &IDLProg, key: &str) -> Option<IDLType> {
+    /// Gets the type of the service init arg.
+    pub fn get_init_arg_type(prog: &IDLProg, key: &str) -> Option<IDLType> {
         prog.decs.iter().find_map(|x| {
             if let Dec::TypD(y) = x {
                 if y.id == key {
@@ -26,8 +26,12 @@ pub mod idl_prog {
     }
 
     /// Gets the arguments for creating a service
-    pub fn get_service_arg(_prog: &IDLProg) -> Option<IDLTypes> {
-        unimplemented!()
+    pub fn get_service_arg(prog: &IDLProg) -> Option<IDLTypes> {
+        if let Some(IDLType::ClassT(args, _)) = &prog.actor {
+            Some(IDLTypes { args: args.clone() })
+        } else {
+            None
+        }
     }
     /// Gets the arguments and return values of a service method.
     ///

--- a/src/idl2json/src/test.rs
+++ b/src/idl2json/src/test.rs
@@ -303,6 +303,13 @@ fn types_should_be_represented_correctly() {
             val: IDLValue::Text("Hi there".to_string()),
             json: r#""Hi there""#,
         },
+
+        TestVector {
+            typ: IDLType::PrimT(PrimType::Nat),
+            val: IDLValue::Nat(candid::Nat(num_bigint::BigUint::from(9999998u64))),
+            json: r#""9_999_998""#,
+        },
+
         TestVector {
             typ: IDLType::PrimT(PrimType::Float32),
             val: IDLValue::Float32(91.0),

--- a/src/idl2json/src/test.rs
+++ b/src/idl2json/src/test.rs
@@ -303,7 +303,6 @@ fn types_should_be_represented_correctly() {
             val: IDLValue::Text("Hi there".to_string()),
             json: r#""Hi there""#,
         },
-
         TestVector {
             typ: IDLType::PrimT(PrimType::Nat),
             val: IDLValue::Nat(candid::Nat(num_bigint::BigUint::from(9999998u64))),
@@ -311,23 +310,53 @@ fn types_should_be_represented_correctly() {
         },
         TestVector {
             typ: IDLType::PrimT(PrimType::Nat8),
-            val: IDLValue::Nat8(8),
-            json: r#"8"#,
+            val: IDLValue::Nat8(u8::MAX),
+            json: r#"255"#,
         },
         TestVector {
             typ: IDLType::PrimT(PrimType::Nat16),
-            val: IDLValue::Nat16(16),
-            json: r#"16"#,
+            val: IDLValue::Nat16(u16::MAX),
+            json: r#"65535"#,
         },
         TestVector {
             typ: IDLType::PrimT(PrimType::Nat32),
-            val: IDLValue::Nat32(32),
-            json: r#"32"#,
+            val: IDLValue::Nat32(u32::MAX),
+            json: r#"4294967295"#,
         },
         TestVector {
             typ: IDLType::PrimT(PrimType::Nat64),
-            val: IDLValue::Nat8(64),
-            json: r#"64"#,
+            val: IDLValue::Nat64(u64::MAX),
+            json: r#""18446744073709551615""#, // Note: quotes as this is too big for JSON.
+        },
+        TestVector {
+            typ: IDLType::PrimT(PrimType::Nat64),
+            val: IDLValue::Nat64(1),
+            json: r#""1""#, // Note: Small u64s are also given as strings, for better or worse.
+        },
+        TestVector {
+            typ: IDLType::PrimT(PrimType::Int8),
+            val: IDLValue::Int8(i8::MIN),
+            json: r#"-128"#,
+        },
+        TestVector {
+            typ: IDLType::PrimT(PrimType::Int16),
+            val: IDLValue::Int16(i16::MIN),
+            json: r#"-32768"#,
+        },
+        TestVector {
+            typ: IDLType::PrimT(PrimType::Int32),
+            val: IDLValue::Int32(i32::MIN),
+            json: r#"-2147483648"#,
+        },
+        TestVector {
+            typ: IDLType::PrimT(PrimType::Int64),
+            val: IDLValue::Int64(i64::MIN),
+            json: r#""-9223372036854775808""#, // Note: Quotes as this is too small for JSON.
+        },
+        TestVector {
+            typ: IDLType::PrimT(PrimType::Int64),
+            val: IDLValue::Int64(-1),
+            json: r#""-1""#, // Note: Small i64s are also in quotes.
         },
         TestVector {
             typ: IDLType::PrimT(PrimType::Float32),

--- a/src/idl2json/src/test.rs
+++ b/src/idl2json/src/test.rs
@@ -278,3 +278,60 @@ fn sample_binaries_are_parsed_with_changed_idl_type() {
         }
     }
 }
+
+/// Verifies that every type is represented in JSON as expected
+#[test]
+fn types_should_be_represented_correctly() {
+    struct TestVector {
+        typ: IDLType,
+        val: IDLValue,
+        json: &'static str,
+    }
+    let test_vectors = vec![
+        TestVector {
+            typ: IDLType::PrimT(PrimType::Bool),
+            val: IDLValue::Bool(true),
+            json: "true",
+        },
+        TestVector {
+            typ: IDLType::PrimT(PrimType::Null),
+            val: IDLValue::Null,
+            json: "null",
+        },
+        TestVector {
+            typ: IDLType::PrimT(PrimType::Text),
+            val: IDLValue::Text("Hi there".to_string()),
+            json: r#""Hi there""#,
+        },
+        TestVector {
+            typ: IDLType::PrimT(PrimType::Float32),
+            val: IDLValue::Float32(91.0),
+            json: r#"91.0"#,
+        },
+        TestVector {
+            typ: IDLType::PrimT(PrimType::Float64),
+            val: IDLValue::Float64(91.0),
+            json: r#"91.0"#,
+        },
+    ];
+    let options = Idl2JsonOptions::default();
+    for TestVector { typ, val, json } in test_vectors {
+        {
+            let actual_json =
+                serde_json::to_string(&idl2json(&val, &options)).expect("Failed to serialize JSON");
+            assert_eq!(
+                json, actual_json,
+                "Failed to get expected representation for type: {typ:?}"
+            );
+        }
+        {
+            let actual_json =
+                serde_json::to_string(&idl2json_with_weak_names(&val, &typ, &options))
+                    .expect("Failed to serialize JSON");
+            assert_eq!(
+                json, actual_json,
+                "Failed to get expected representation for type, when weak names are used: {typ:?}"
+            );
+        }
+    }
+}

--- a/src/idl2json/src/test.rs
+++ b/src/idl2json/src/test.rs
@@ -88,7 +88,7 @@ fn test_vector() -> BinaryTestVector {
     22, 174, 254, 224, 59, 183, 254, 184, 33, 174, 244, 52, 103, 82, 105, 116, 244, 112, 205,
     75, 7, 1, 0, 16, 165, 212, 232, 0, 0, 0,
     ],  json_options: vec![
-    ( Idl2JsonOptions{ bytes_as: Some(BytesFormat::Numbers), long_bytes_as: None },
+    ( Idl2JsonOptions{ bytes_as: Some(BytesFormat::Numbers), long_bytes_as: None, ..Idl2JsonOptions::default() },
         r#"[{
             "2_138_241_783":["1000000000000"],
             "451_920_964":[[246,145,242,105,221,102,170,79,196,78,105,22,174,254,224,59,183,254,184,33,174,244,52,103,82,105,116,244,112,205,75,7]]
@@ -102,7 +102,7 @@ fn test_vector() -> BinaryTestVector {
             "archive_module_hash":[[246,145,242,105,221,102,170,79,196,78,105,22,174,254,224,59,183,254,184,33,174,244,52,103,82,105,116,244,112,205,75,7]]
         }]"#.to_string()
     ),
-    ( Idl2JsonOptions{ bytes_as: Some(BytesFormat::Hex), long_bytes_as: None },
+    ( Idl2JsonOptions{ bytes_as: Some(BytesFormat::Hex), long_bytes_as: None, ..Idl2JsonOptions::default() },
         r#"[{
             "2_138_241_783":["1000000000000"],
             "451_920_964":["f691f269dd66aa4fc44e6916aefee03bb7feb821aef43467526974f470cd4b07"]
@@ -116,7 +116,7 @@ fn test_vector() -> BinaryTestVector {
             "archive_module_hash":["f691f269dd66aa4fc44e6916aefee03bb7feb821aef43467526974f470cd4b07"]
         }]"#.to_string()
     ),
-    ( Idl2JsonOptions{ bytes_as: Some(BytesFormat::Sha256), long_bytes_as: None },
+    ( Idl2JsonOptions{ bytes_as: Some(BytesFormat::Sha256), long_bytes_as: None, ..Idl2JsonOptions::default() },
         r#"[{
             "2_138_241_783":["1000000000000"],
             "451_920_964":["Bytes with sha256: ac0c88f389e4af11790089d940f8483905e8766de960ccd847d0500b4caf6acf"]}]"#.to_string(),
@@ -129,7 +129,7 @@ fn test_vector() -> BinaryTestVector {
             "archive_module_hash":["Bytes with sha256: ac0c88f389e4af11790089d940f8483905e8766de960ccd847d0500b4caf6acf"]
         }]"#.to_string()
     ),
-        ( Idl2JsonOptions{ bytes_as: Some(BytesFormat::Sha256), long_bytes_as: Some((1000, BytesFormat::Hex)) },
+        ( Idl2JsonOptions{ bytes_as: Some(BytesFormat::Sha256), long_bytes_as: Some((1000, BytesFormat::Hex)), ..Idl2JsonOptions::default() },
         r#"[
             {"2_138_241_783":["1000000000000"],
             "451_920_964":["Bytes with sha256: ac0c88f389e4af11790089d940f8483905e8766de960ccd847d0500b4caf6acf"]
@@ -143,7 +143,7 @@ fn test_vector() -> BinaryTestVector {
             "archive_module_hash":["Bytes with sha256: ac0c88f389e4af11790089d940f8483905e8766de960ccd847d0500b4caf6acf"]
         }]"#.to_string()
         ),
-         ( Idl2JsonOptions{ bytes_as: Some(BytesFormat::Sha256), long_bytes_as: Some((5, BytesFormat::Hex)) },
+         ( Idl2JsonOptions{ bytes_as: Some(BytesFormat::Sha256), long_bytes_as: Some((5, BytesFormat::Hex)), ..Idl2JsonOptions::default() },
          r#"[{
             "2_138_241_783":["1000000000000"],
             "451_920_964":["f691f269dd66aa4fc44e6916aefee03bb7feb821aef43467526974f470cd4b07"]

--- a/src/idl2json/src/test.rs
+++ b/src/idl2json/src/test.rs
@@ -309,7 +309,26 @@ fn types_should_be_represented_correctly() {
             val: IDLValue::Nat(candid::Nat(num_bigint::BigUint::from(9999998u64))),
             json: r#""9_999_998""#,
         },
-
+        TestVector {
+            typ: IDLType::PrimT(PrimType::Nat8),
+            val: IDLValue::Nat8(8),
+            json: r#"8"#,
+        },
+        TestVector {
+            typ: IDLType::PrimT(PrimType::Nat16),
+            val: IDLValue::Nat16(16),
+            json: r#"16"#,
+        },
+        TestVector {
+            typ: IDLType::PrimT(PrimType::Nat32),
+            val: IDLValue::Nat32(32),
+            json: r#"32"#,
+        },
+        TestVector {
+            typ: IDLType::PrimT(PrimType::Nat64),
+            val: IDLValue::Nat8(64),
+            json: r#"64"#,
+        },
         TestVector {
             typ: IDLType::PrimT(PrimType::Float32),
             val: IDLValue::Float32(91.0),

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -36,6 +36,8 @@ pub fn idl2json_with_weak_names(
             if let Some(resolved_type) = get_type_from_any(&options.prog, type_name) {
                 idl2json_with_weak_names(idl, &resolved_type, options)
             } else {
+                // TODO: Return a set of warnings.  Under the "best effort" mantra, we proceed as
+                // best we can but it would be nice to provide some feedback.
                 eprintln!("Warning: Type not found: '{type_name}'");
                 idl2json(idl, options)
             }

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -31,6 +31,13 @@ pub fn idl2json_with_weak_names(
     options: &Idl2JsonOptions,
 ) -> JsonValue {
     match (idl, idl_type) {
+        (idl, IDLType::VarT(type_name)) => {
+            if let Some(resolved_type) = get_type_from_any(&options.prog, type_name) {
+                idl2json_with_weak_names(idl, &resolved_type, options)
+            } else {
+                idl2json(idl, options)
+            }
+        }
         (IDLValue::Bool(bool), _) => JsonValue::Bool(*bool),
         (IDLValue::Null, _) => JsonValue::Null,
         (IDLValue::Text(s), _) => JsonValue::String(s.clone()),

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -32,9 +32,11 @@ pub fn idl2json_with_weak_names(
 ) -> JsonValue {
     match (idl, idl_type) {
         (idl, IDLType::VarT(type_name)) => {
+            eprintln!("Looking up type '{type_name}'");
             if let Some(resolved_type) = get_type_from_any(&options.prog, type_name) {
                 idl2json_with_weak_names(idl, &resolved_type, options)
             } else {
+                eprintln!("Warning: Type not found: '{type_name}'");
                 idl2json(idl, options)
             }
         }

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use candid::{
     parser::{
         types::{IDLType, IDLTypes, PrimType, TypeField},
@@ -121,8 +123,11 @@ fn convert_idl_field(
 /// Converts a candid IDLArgs to a serde JsonValue, with keys as names where possible.
 pub fn idl_args2json_with_weak_names(
     _idl: &IDLArgs,
-    _idl_type: &IDLTypes,
+    idl_types: &IDLTypes,
     _options: &Idl2JsonOptions,
 ) -> JsonValue {
+    /// If insufficient types are provided, we still include the remaining values interpreted with an empty type.
+    let extension_type = IDLType::PrimT(PrimType::Null);
+    let idl_type_extension = idl_types.args.iter().chain(iter::repeat(&extension_type));
     unimplemented!()
 }

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -151,5 +151,7 @@ pub fn idl_args2json_with_weak_names(
 ///
 /// Note: A canister .did file represents an IDLProg.  That canister .did file may depend on definitions made elsewhere.
 pub fn get_type_from_any(progs: &[IDLProg], name: &str) -> Option<IDLType> {
-    progs.iter().find_map(|prog| crate::polyfill::idl_prog::get_type(prog, name))
+    progs
+        .iter()
+        .find_map(|prog| crate::polyfill::idl_prog::get_type(prog, name))
 }

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -140,25 +140,9 @@ pub fn idl_args2json_with_weak_names(
     )
 }
 
-/// Get a type definition from an IDLProg.
-///
-/// Note: A canister .did file represents an IDLProg.
-pub fn get_type(_name: &str, _prog: &IDLProg) -> Option<IDLType> {
-    unimplemented!()
-}
 /// Find a type in any of a list of IDLProgs.
 ///
 /// Note: A canister .did file represents an IDLProg.  That canister .did file may depend on definitions made elsewhere.
-pub fn get_type_from_any(name: &str, progs: &[IDLProg]) -> Option<IDLType> {
-    progs.iter().find_map(|prog| get_type(name, prog))
-}
-/// Gets the arguments for creating a service
-pub fn get_service_arg(_prog: &IDLProg) -> Option<IDLTypes> {
-    unimplemented!()
-}
-/// Gets the arguments and return values of a service method.
-///
-/// Note: In a canister .did file there is typically a service section containing these service methods.
-pub fn get_fn_type(_fn_name: &str, _prog: &IDLProg) -> Option<(IDLTypes, IDLTypes)> {
-    unimplemented!()
+pub fn get_type_from_any(progs: &[IDLProg], name: &str) -> Option<IDLType> {
+    progs.iter().find_map(|prog| crate::polyfill::idl_prog::get_type(prog, name))
 }

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -122,12 +122,20 @@ fn convert_idl_field(
 
 /// Converts a candid IDLArgs to a serde JsonValue, with keys as names where possible.
 pub fn idl_args2json_with_weak_names(
-    _idl: &IDLArgs,
+    idl: &IDLArgs,
     idl_types: &IDLTypes,
-    _options: &Idl2JsonOptions,
+    options: &Idl2JsonOptions,
 ) -> JsonValue {
-    /// If insufficient types are provided, we still include the remaining values interpreted with an empty type.
+    // If insufficient types are provided, this function includes the remaining values interpreted with a null type,
+    // yielding an untyped conversion for the remaining fields.
     let extension_type = IDLType::PrimT(PrimType::Null);
     let idl_type_extension = idl_types.args.iter().chain(iter::repeat(&extension_type));
-    unimplemented!()
+    // Matches each value with the corresponding type.
+    JsonValue::Array(
+        idl.args
+            .iter()
+            .zip(idl_type_extension)
+            .map(|(value, typ)| idl2json_with_weak_names(value, typ, options))
+            .collect(),
+    )
 }

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -5,7 +5,7 @@ use candid::{
         types::{IDLType, IDLTypes, PrimType, TypeField},
         value::{IDLField, IDLValue},
     },
-    IDLArgs,
+    IDLArgs, IDLProg,
 };
 use serde_json::value::Value as JsonValue;
 
@@ -138,4 +138,27 @@ pub fn idl_args2json_with_weak_names(
             .map(|(value, typ)| idl2json_with_weak_names(value, typ, options))
             .collect(),
     )
+}
+
+/// Get a type definition from an IDLProg.
+///
+/// Note: A canister .did file represents an IDLProg.
+pub fn get_type(_name: &str, _prog: &IDLProg) -> Option<IDLType> {
+    unimplemented!()
+}
+/// Find a type in any of a list of IDLProgs.
+///
+/// Note: A canister .did file represents an IDLProg.  That canister .did file may depend on definitions made elsewhere.
+pub fn get_type_from_any(name: &str, progs: &[IDLProg]) -> Option<IDLType> {
+    progs.iter().find_map(|prog| get_type(name, prog))
+}
+/// Gets the arguments for creating a service
+pub fn get_service_arg(_prog: &IDLProg) -> Option<IDLTypes> {
+    unimplemented!()
+}
+/// Gets the arguments and return values of a service method.
+///
+/// Note: In a canister .did file there is typically a service section containing these service methods.
+pub fn get_fn_type(_fn_name: &str, _prog: &IDLProg) -> Option<(IDLTypes, IDLTypes)> {
+    unimplemented!()
 }

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -1,6 +1,9 @@
-use candid::parser::{
-    types::{IDLType, PrimType, TypeField},
-    value::{IDLField, IDLValue},
+use candid::{
+    parser::{
+        types::{IDLType, IDLTypes, PrimType, TypeField},
+        value::{IDLField, IDLValue},
+    },
+    IDLArgs,
 };
 use serde_json::value::Value as JsonValue;
 
@@ -16,6 +19,10 @@ use crate::{
 /// - Fields are never added, even if the schema suggests that some fields are missing.
 ///
 /// The data is preserved at all cost, the schema is applied only to make the data easier to understand and use.
+///
+/// Note: The textual format in parentheses `(  )` represents IDLArgs containing
+/// zero or more IDLValues.  Unless you definitely wish to convert a single value
+/// you may wish to consider `idl_args2json_with_weak_names` instead.
 pub fn idl2json_with_weak_names(
     idl: &IDLValue,
     idl_type: &IDLType,
@@ -109,4 +116,13 @@ fn convert_idl_field(
             )
         })
         .unwrap_or_else(|| (field.id.to_string(), idl2json(&field.val, options)))
+}
+
+/// Converts a candid IDLArgs to a serde JsonValue, with keys as names where possible.
+pub fn idl_args2json_with_weak_names(
+    _idl: &IDLArgs,
+    _idl_type: &IDLTypes,
+    _options: &Idl2JsonOptions,
+) -> JsonValue {
+    unimplemented!()
 }

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -32,13 +32,11 @@ pub fn idl2json_with_weak_names(
 ) -> JsonValue {
     match (idl, idl_type) {
         (idl, IDLType::VarT(type_name)) => {
-            eprintln!("Looking up type '{type_name}'");
             if let Some(resolved_type) = get_type_from_any(&options.prog, type_name) {
                 idl2json_with_weak_names(idl, &resolved_type, options)
             } else {
                 // TODO: Return a set of warnings.  Under the "best effort" mantra, we proceed as
                 // best we can but it would be nice to provide some feedback.
-                eprintln!("Warning: Type not found: '{type_name}'");
                 idl2json(idl, options)
             }
         }

--- a/src/idl2json/src/untyped_conversion.rs
+++ b/src/idl2json/src/untyped_conversion.rs
@@ -68,6 +68,6 @@ pub(crate) fn convert_non_bytes_array(value: &[IDLValue], options: &Idl2JsonOpti
 /// Converts a candid IDLArgs to a serde JsonValue, without type information.
 ///
 /// Note: The textual format `( )` containing zero or more vaues represents an IDLArgs.
-pub fn idl_args2json(_args: &IDLArgs, _options: &Idl2JsonOptions) -> JsonValue {
-    unimplemented!()
+pub fn idl_args2json(args: &IDLArgs, options: &Idl2JsonOptions) -> JsonValue {
+    convert_non_bytes_array(&args.args, options)
 }

--- a/src/idl2json/src/untyped_conversion.rs
+++ b/src/idl2json/src/untyped_conversion.rs
@@ -67,7 +67,7 @@ pub(crate) fn convert_non_bytes_array(value: &[IDLValue], options: &Idl2JsonOpti
 
 /// Converts a candid IDLArgs to a serde JsonValue, without type information.
 ///
-/// Note: The textual format `( )` containing zero or more vaues represents an IDLArgs.
+/// Note: The textual format `( )` containing zero or more values represents an IDLArgs.
 pub fn idl_args2json(args: &IDLArgs, options: &Idl2JsonOptions) -> JsonValue {
     convert_non_bytes_array(&args.args, options)
 }

--- a/src/idl2json/src/untyped_conversion.rs
+++ b/src/idl2json/src/untyped_conversion.rs
@@ -1,9 +1,14 @@
 use candid::parser::value::IDLValue;
+use candid::IDLArgs;
 use serde_json::value::Value as JsonValue;
 
 use crate::{bytes::convert_bytes, Idl2JsonOptions};
 
 /// Converts a candid IDLValue to a serde JsonValue, without type information.
+///
+/// Note: The textual format in parentheses `(  )` represents IDLArgs containing
+/// zero or more IDLValues.  Unless you definitely wish to convert a single value
+/// you may wish to consider `idl_args2json` instead.
 pub fn idl2json(idl: &IDLValue, options: &Idl2JsonOptions) -> JsonValue {
     match idl {
         IDLValue::Bool(bool) => JsonValue::Bool(*bool),
@@ -58,4 +63,11 @@ pub fn idl2json(idl: &IDLValue, options: &Idl2JsonOptions) -> JsonValue {
 /// Conver
 pub(crate) fn convert_non_bytes_array(value: &[IDLValue], options: &Idl2JsonOptions) -> JsonValue {
     JsonValue::Array(value.iter().map(|item| idl2json(item, options)).collect())
+}
+
+/// Converts a candid IDLArgs to a serde JsonValue, without type information.
+///
+/// Note: The textual format `( )` containing zero or more vaues represents an IDLArgs.
+pub fn idl_args2json(_args: &IDLArgs, _options: &Idl2JsonOptions) -> JsonValue {
+    unimplemented!()
 }

--- a/src/idl2json_cli/src/lib.rs
+++ b/src/idl2json_cli/src/lib.rs
@@ -72,7 +72,6 @@ pub fn main(args: &Args, idl_str: &str) -> anyhow::Result<String> {
             .context("Failed to serialize to json")
         } else {
             let idl_type = IDLType::from_str(idl_type).context("Failed to parse type")?;
-            eprintln!("Type: {idl_type:?}");
             convert_all(&idl_args, &Some(idl_type), &idl2json_options)
         }
     } else {

--- a/src/idl2json_cli/src/lib.rs
+++ b/src/idl2json_cli/src/lib.rs
@@ -10,9 +10,14 @@ mod tests;
 
 use anyhow::{anyhow, Context};
 use candid::parser::value::IDLValue;
-use candid::{parser::types::{IDLType, IDLTypes}, IDLArgs, IDLProg};
+use candid::{
+    parser::types::{IDLType, IDLTypes},
+    IDLArgs, IDLProg,
+};
 use clap::Parser;
-use idl2json::{idl2json, idl2json_with_weak_names, Idl2JsonOptions};
+use idl2json::{
+    idl2json, idl2json_with_weak_names, idl_args2json_with_weak_names, Idl2JsonOptions,
+};
 use std::{path::PathBuf, str::FromStr};
 
 /// Reads IDL from stdin, writes JSON to stdout.
@@ -37,7 +42,12 @@ pub fn main(args: &Args, idl_str: &str) -> anyhow::Result<String> {
     if let Some(idl_type) = &args.typ {
         if idl_type.trim().starts_with('(') {
             let idl_types = IDLTypes::from_str(idl_type).context("Failed to parse type")?;
-            unimplemented!()
+            serde_json::to_string(&idl_args2json_with_weak_names(
+                &idl_args,
+                &idl_types,
+                &idl2json_options,
+            ))
+            .context("Failed to serialize to json")
         } else {
             let idl_type = IDLType::from_str(idl_type).context("Failed to parse type")?;
             eprintln!("Type: {idl_type:?}");

--- a/src/idl2json_cli/src/lib.rs
+++ b/src/idl2json_cli/src/lib.rs
@@ -16,7 +16,7 @@ use candid::{
 };
 use clap::Parser;
 use idl2json::{
-    idl2json, idl2json_with_weak_names, idl_args2json_with_weak_names, Idl2JsonOptions,
+    idl2json, idl2json_with_weak_names, idl_args2json_with_weak_names, polyfill, Idl2JsonOptions,
 };
 use std::{path::PathBuf, str::FromStr};
 
@@ -25,21 +25,43 @@ pub fn main(args: &Args, idl_str: &str) -> anyhow::Result<String> {
     let idl_args: IDLArgs = idl_str
         .parse()
         .with_context(|| anyhow!("Malformed input"))?;
-    let progs: anyhow::Result<Vec<IDLProg>> = args
-        .did
-        .iter()
-        .map(|did| {
-            let did_as_str = std::fs::read_to_string(did)
-                .with_context(|| anyhow!("Could not read did file '{}'.", did.display()))?;
-            IDLProg::from_str(&did_as_str)
-                .with_context(|| anyhow!("Failed to parse did file '{}'", did.display()))
-        })
-        .collect();
-    let idl2json_options = Idl2JsonOptions {
-        prog: progs?,
-        ..Idl2JsonOptions::default()
+    let idl2json_options = {
+        let progs: anyhow::Result<Vec<IDLProg>> = args
+            .did
+            .iter()
+            .map(|did| {
+                let did_as_str = std::fs::read_to_string(did)
+                    .with_context(|| anyhow!("Could not read did file '{}'.", did.display()))?;
+                IDLProg::from_str(&did_as_str)
+                    .with_context(|| anyhow!("Failed to parse did file '{}'", did.display()))
+            })
+            .collect();
+        let progs = progs?;
+
+        Idl2JsonOptions {
+            prog: progs,
+            ..Idl2JsonOptions::default()
+        }
     };
-    if let Some(idl_type) = &args.typ {
+    // Decide what to do
+    if args.init {
+        // Use the type of the .did file init arg.
+        // - If multiple did files are provided, the first is used.
+        // - Clap should reject commands without a --did file.
+        let idl_types = polyfill::idl_prog::get_init_arg_type(
+            idl2json_options
+                .prog
+                .get(0)
+                .context("Please specify which .did file to use.")?,
+        )
+        .context("Failed to get the service argument from the did file.")?;
+        serde_json::to_string(&idl_args2json_with_weak_names(
+            &idl_args,
+            &idl_types,
+            &idl2json_options,
+        ))
+        .context("Failed to serialize to json")
+    } else if let Some(idl_type) = &args.typ {
         if idl_type.trim().starts_with('(') {
             let idl_types = IDLTypes::from_str(idl_type).context("Failed to parse type")?;
             serde_json::to_string(&idl_args2json_with_weak_names(
@@ -96,4 +118,7 @@ pub struct Args {
     /// The name of a type in the provided .did file
     #[clap(short, long)]
     typ: Option<String>,
+    /// Use the service init argument type from the did file
+    #[clap(short, long, requires("did"))]
+    init: bool,
 }

--- a/src/idl2json_cli/src/lib.rs
+++ b/src/idl2json_cli/src/lib.rs
@@ -10,7 +10,7 @@ mod tests;
 
 use anyhow::{anyhow, Context};
 use candid::parser::value::IDLValue;
-use candid::{parser::types::IDLType, IDLArgs, IDLProg};
+use candid::{parser::types::{IDLType, IDLTypes}, IDLArgs, IDLProg};
 use clap::Parser;
 use idl2json::{idl2json, idl2json_with_weak_names, Idl2JsonOptions};
 use std::{path::PathBuf, str::FromStr};
@@ -36,6 +36,7 @@ pub fn main(args: &Args, idl_str: &str) -> anyhow::Result<String> {
     };
     if let Some(idl_type) = &args.typ {
         if idl_type.trim().starts_with('(') {
+            let idl_types = IDLTypes::from_str(idl_type).context("Failed to parse type")?;
             unimplemented!()
         } else {
             let idl_type = IDLType::from_str(idl_type).context("Failed to parse type")?;

--- a/src/idl2json_cli/src/lib.rs
+++ b/src/idl2json_cli/src/lib.rs
@@ -65,7 +65,11 @@ fn get_idl_type(args: &Args) -> anyhow::Result<Option<IDLType>> {
             })?
         };
         Ok(Some(idl_type))
-    } else {
+    } else if let Some( typ ) = &args.typ {
+        let idl_type = IDLType::from_str(typ)?;
+        eprintln!("Type: {idl_type:?}");
+        Ok(Some(idl_type))
+    }else {
         Ok(None)
     }
 }

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -81,12 +81,9 @@ fn conversion_with_options_should_be_correct() {
         // (record { 2_138_241_783 = opt (999 : int) })
         // {"canister_creation_cycles_cost":["911"]}
         TestVector {
-            stdin: "(record { 2_138_241_783 = opt (999 : int) })",
-            args: typed_arg!(
-                "internet_identity.did",
-                "record { canister_creation_cycles_cost: nat32; }"
-            ),
-            stdout: r#"{"canister_creation_cycles_cost":["999"]"#,
+            stdin: "(record { 2_138_241_783 = opt (911 : int) })",
+            args: Args{typ: Some("record { canister_creation_cycles_cost: nat32; }".to_string()), ..Args::default()},
+            stdout: r#"{"canister_creation_cycles_cost":["911"]}"#,
         },
     ];
     for vector in vectors {

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -29,3 +29,42 @@ fn simple_conversion_should_be_correct() {
         assert_eq!(vector.stdout, &out)
     }
 }
+
+#[test]
+fn conversion_with_a_standalone_type_should_be_correct() {
+    struct TestVector {
+        name: &'static str,
+        stdin: &'static str,
+        typ: &'static str,
+        stdout: &'static str,
+    }
+    let args = Args::default();
+    let vectors = [
+        TestVector {
+            name: "typed record",
+            stdin: "( record {foo=1; bar=2;} )",
+            typ: "record { foo: nat8, bar: nat8 }",
+            stdout: "{\"bar\":\"2\",\"foo\":\"1\"}",
+        },
+        TestVector {
+            name: "untyped record",
+            stdin: "(record { 4_895_187 = 2 : int; 5_097_222 = 1 : int })", // created with: echo "( record {foo=1; bar=2;} )" | didc encode | didc decode
+            typ: "record { foo: nat8, bar: nat8 }",
+            stdout: "{\"bar\":\"2\",\"foo\":\"1\"}",
+        },
+    ];
+    for vector in vectors {
+        let out = main(&args, vector.stdin)
+            .map_err(|e| anyhow!("Failed to parse: {} due to: {e}", vector.stdin))
+            .unwrap();
+        assert_eq!(vector.stdout, &out, "Incorrect output for {}", vector.name)
+    }
+}
+
+// TODO: conversion with a standalone IDLTypes
+
+// TODO: conversion with alooked - up type
+
+// TODO: Conversion with idlargs containing looked-up types
+
+// TODO: Tarpaulin tests

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -135,12 +135,23 @@ fn error_handling_should_be_correct() {
         args: Args,
         err: &'static str,
     }
-    let vectors = [TestVector {
-        name: "Invalid candid on stdin",
-        stdin: "( this is not candid",
-        args: Args::default(),
-        err: "Malformed input",
-    }];
+    let vectors = [
+        TestVector {
+            name: "Invalid candid on stdin",
+            stdin: "( this is not candid",
+            args: Args::default(),
+            err: "Malformed input",
+        },
+        TestVector {
+            name: "Request init args without supplying a did file",
+            stdin: r#"("Perfictly  valid candid")"#,
+            args: Args {
+                init: true,
+                ..Args::default()
+            },
+            err: "Please specify which .did file to use.",
+        },
+    ];
     for (index, vector) in vectors.iter().enumerate() {
         match main(&vector.args, vector.stdin) {
             Ok(json) => panic!(

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -54,6 +54,7 @@ macro_rules! typed_arg {
         Args {
             did: vec![sample_file!($did_file)],
             typ: Some($typ.to_string()),
+            init: false,
         }
     };
 }
@@ -102,6 +103,20 @@ fn conversion_with_options_should_be_correct() {
                 ..Args::default()
             },
             stdout: r#"[{"canister_creation_cycles_cost":["42"]}]"#,
+        },
+        // We shoudl be able to parse a service init type.
+        // On the command line we should see:
+        // $ echo "(opt record{canister_creation_cycles_cost= opt 6974;})" | didc encode | didc decode | tee /dev/stderr | target/debug/idl2json --did samples/internet_identity.did  --init
+        // (opt record { 2_138_241_783 = opt (6_974 : int) })
+        // [[{"canister_creation_cycles_cost":["6_974"]}]]
+        TestVector {
+            stdin: "(opt record { 2_138_241_783 = opt (6_974 : int) })",
+            args: Args {
+                did: vec![sample_file!("internet_identity.did")],
+                typ: None,
+                init: true,
+            },
+            stdout: r#"[[{"canister_creation_cycles_cost":["6_974"]}]]"#,
         },
     ];
     for vector in vectors {

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -67,6 +67,7 @@ fn conversion_with_options_should_be_correct() {
         stdout: &'static str,
     }
     let vectors = [
+        // We should be able to use a named type in a did file:
         // On the command line we should see:
         // $ echo "(record{canister_creation_cycles_cost= opt 999;})" | didc encode | didc decode | tee /dev/stderr | idl2json --did samples/internet_identity.did  --typ InternetIdentityInit
         // (record { 2_138_241_783 = opt (999 : int) })
@@ -76,6 +77,7 @@ fn conversion_with_options_should_be_correct() {
             args: typed_arg!("internet_identity.did", "InternetIdentityInit"),
             stdout: r#"{"canister_creation_cycles_cost":["999"]}"#,
         },
+        // We should be able to specify a type literally.
         // On the command line we should see:
         // echo "(record{canister_creation_cycles_cost= opt 999;})" | didc encode | didc decode | tee /dev/stderr | target/debug/idl2json --did samples/internet_identity.did  --typ 'record { canister_creation_cycles_cost: nat32; }'
         // (record { 2_138_241_783 = opt (999 : int) })

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -1,19 +1,31 @@
 use super::{main, Args};
-use anyhow::{anyhow, Context};
+use anyhow::anyhow;
 
 #[test]
 fn simple_conversion_should_be_correct() {
-   struct TestVector {
-     stdin: &'static str, stdout: &'static str
-   }
-   let args = Args::default();
+    struct TestVector {
+        stdin: &'static str,
+        stdout: &'static str,
+    }
+    let args = Args::default();
     let vectors = [
-     TestVector{ stdin: "()", stdout: "\n" }
-     TestVector{ stdin: "( record {} )", stdout: "{}\n" }
-     TestVector{ stdin: "( record {}, record {} )", stdout: "{}\n{}\n" }
-  ];
-  for vector in vectors {
-      let out = main(&args, vector.stdin).map_err(|e| anyhow!("Failed to parse: {} due to: {e}", vector.stdin)).unwrap();
-    assert_eq!(vector.stdout, &out)
-  }
+        TestVector {
+            stdin: "()",
+            stdout: "",
+        },
+        TestVector {
+            stdin: "( record {} )",
+            stdout: "{}",
+        },
+        TestVector {
+            stdin: "( record {}, record {} )",
+            stdout: "{}\n{}",
+        },
+    ];
+    for vector in vectors {
+        let out = main(&args, vector.stdin)
+            .map_err(|e| anyhow!("Failed to parse: {} due to: {e}", vector.stdin))
+            .unwrap();
+        assert_eq!(vector.stdout, &out)
+    }
 }

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -101,7 +101,7 @@ fn conversion_with_options_should_be_correct() {
                 typ: Some("(record { canister_creation_cycles_cost: nat32; })".to_string()),
                 ..Args::default()
             },
-            stdout: r#"{"canister_creation_cycles_cost":["42"]}"#,
+            stdout: r#"[{"canister_creation_cycles_cost":["42"]}]"#,
         },
     ];
     for vector in vectors {

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -78,6 +78,16 @@ fn conversion_with_options_should_be_correct() {
             args: typed_arg!("internet_identity.did", "InternetIdentityInit"),
             stdout: r#"{"canister_creation_cycles_cost":["999"]}"#,
         },
+        // If a type name cannot be found, conversion should proceed on a best effort basis.
+        // On the command line we should see:
+        // $ echo "(record{canister_creation_cycles_cost= opt 999;})" | didc encode | didc decode | tee /dev/stderr | target/debug/idl2json --did samples/internet_identity.did  --typ IInnit
+        // (record { 2_138_241_783 = opt (999 : int) })
+        // {"2_138_241_783":["999"]}
+        TestVector {
+            stdin: "(record { 2_138_241_783 = opt (999 : int) })",
+            args: typed_arg!("internet_identity.did", "IInnit"),
+            stdout: r#"{"2_138_241_783":["999"]}"#,
+        },
         // We should be able to specify a type literally.
         // On the command line we should see:
         // echo "(record{canister_creation_cycles_cost= opt 999;})" | didc encode | didc decode | tee /dev/stderr | target/debug/idl2json --did samples/internet_identity.did  --typ 'record { canister_creation_cycles_cost: nat32; }'

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -120,7 +120,6 @@ fn conversion_with_options_should_be_correct() {
         },
     ];
     for vector in vectors {
-        eprintln!("{vector:#?}");
         let out = main(&vector.args, vector.stdin)
             .map_err(|e| anyhow!("Failed to parse: {} due to: {e}", vector.stdin))
             .unwrap();

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -94,14 +94,12 @@ fn error_handling_should_be_correct() {
         args: Args,
         err: &'static str,
     }
-    let vectors = [
-        TestVector {
-            name: "Invalid candid on stdin",
-            stdin: "( this is not candid",
-            args: Args::default(),
-            err: "Malformed input",
-        },
-    ];
+    let vectors = [TestVector {
+        name: "Invalid candid on stdin",
+        stdin: "( this is not candid",
+        args: Args::default(),
+        err: "Malformed input",
+    }];
     for (index, vector) in vectors.iter().enumerate() {
         match main(&vector.args, vector.stdin) {
             Ok(json) => panic!(

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -82,7 +82,10 @@ fn conversion_with_options_should_be_correct() {
         // {"canister_creation_cycles_cost":["911"]}
         TestVector {
             stdin: "(record { 2_138_241_783 = opt (911 : int) })",
-            args: Args{typ: Some("record { canister_creation_cycles_cost: nat32; }".to_string()), ..Args::default()},
+            args: Args {
+                typ: Some("record { canister_creation_cycles_cost: nat32; }".to_string()),
+                ..Args::default()
+            },
             stdout: r#"{"canister_creation_cycles_cost":["911"]}"#,
         },
     ];

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -46,12 +46,13 @@ fn conversion_with_a_standalone_type_should_be_correct() {
             typ: "record { foo: nat8, bar: nat8 }",
             stdout: "{\"bar\":\"2\",\"foo\":\"1\"}",
         },
+        /*
         TestVector {
             name: "untyped record",
             stdin: "(record { 4_895_187 = 2 : int; 5_097_222 = 1 : int })", // created with: echo "( record {foo=1; bar=2;} )" | didc encode | didc decode
             typ: "record { foo: nat8, bar: nat8 }",
             stdout: "{\"bar\":\"2\",\"foo\":\"1\"}",
-        },
+        },*/
     ];
     for vector in vectors {
         let out = main(&args, vector.stdin)

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -101,12 +101,6 @@ fn error_handling_should_be_correct() {
             args: Args::default(),
             err: "Malformed input",
         },
-        TestVector {
-            name: "Typo in type name",
-            stdin: r#"( "perfectly valid candid" )"#,
-            args: typed_arg!("internet_identity.did", "IIInnit"),
-            err: r#"Type 'IIInnit' not found in .did file"#,
-        },
     ];
     for (index, vector) in vectors.iter().enumerate() {
         match main(&vector.args, vector.stdin) {

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -76,6 +76,18 @@ fn conversion_with_options_should_be_correct() {
             args: typed_arg!("internet_identity.did", "InternetIdentityInit"),
             stdout: r#"{"canister_creation_cycles_cost":["999"]}"#,
         },
+        // On the command line we should see:
+        // echo "(record{canister_creation_cycles_cost= opt 999;})" | didc encode | didc decode | tee /dev/stderr | target/debug/idl2json --did samples/internet_identity.did  --typ 'record { canister_creation_cycles_cost: nat32; }'
+        // (record { 2_138_241_783 = opt (999 : int) })
+        // {"canister_creation_cycles_cost":["911"]}
+        TestVector {
+            stdin: "(record { 2_138_241_783 = opt (999 : int) })",
+            args: typed_arg!(
+                "internet_identity.did",
+                "record { canister_creation_cycles_cost: nat32; }"
+            ),
+            stdout: r#"{"canister_creation_cycles_cost":["999"]"#,
+        },
     ];
     for vector in vectors {
         eprintln!("{vector:#?}");

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -90,6 +90,19 @@ fn conversion_with_options_should_be_correct() {
             },
             stdout: r#"{"canister_creation_cycles_cost":["911"]}"#,
         },
+        // We should be able to specify IDLTypes literally
+        // On the command line we should see:
+        // echo "(record{canister_creation_cycles_cost= opt 999;})" | didc encode | didc decode | tee /dev/stderr | target/debug/idl2json --did samples/internet_identity.did  --typ '(record { canister_creation_cycles_cost: nat32; })'
+        // (record { 2_138_241_783 = opt (999 : int) })
+        // [{"canister_creation_cycles_cost":["911"]}]
+        TestVector {
+            stdin: "(record { 2_138_241_783 = opt (42 : int) })",
+            args: Args {
+                typ: Some("(record { canister_creation_cycles_cost: nat32; })".to_string()),
+                ..Args::default()
+            },
+            stdout: r#"{"canister_creation_cycles_cost":["42"]}"#,
+        },
     ];
     for vector in vectors {
         eprintln!("{vector:#?}");


### PR DESCRIPTION
# Motivation
We wish to be able to convert proposal arguments to JSON.  This requires:
- Canister arguments are of type IDLArgs which is a vector of types, rather than one IDLType.  Assuming that the argument is just one IDLType leads to errors that have to be handled downstream.  It is better to fix it here, at source.
- Canister arguments often refer to types defined in the did file.  The did file is an IDLProg which has a declarations section, where these types are defined.  Thus we need optional support for providing one (or more) IDLProgs and looking in them for type definitions. If a type is not found, we fall back to unannotated conversion to JSON.
- We need to be able to extract init args from a did file. There is already code for this in the nns-dapp repo that we can steal.
- We also need tests, to make sure that we don't break backwards compatibility more than necessary as we add these features.

# Changes
- All of the above, basically.  Lots of tests and the functionality described there.
- Added support for the above functionality to the idl2json CLI.