### PR TITLE
Enable tests for idl2json_cli

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -94,7 +94,7 @@ jobs:
           path: tarpaulin-report.html
 
       - name: Check code coverage percentage
-        run: jq -e '.files | reduce .[] as $num ([0,0]; [.[0]+$num.coverable, .[1]+$num.covered]) | (.[1] * 100 / .[0]) >= 60' tarpaulin-report.json
+        run: jq -e '.files | reduce .[] as $num ([0,0]; [.[0]+$num.coverable, .[1]+$num.covered]) | (.[1] * 100 / .[0]) >= 69' tarpaulin-report.json
 
   may-merge:
     needs: ["check", "test", "fmt", "clippy"]

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -94,7 +94,7 @@ jobs:
           path: tarpaulin-report.html
 
       - name: Check code coverage percentage
-        run: jq -e '.files | reduce .[] as $num ([0,0]; [.[0]+$num.coverable, .[1]+$num.covered]) | (.[1] * 100 / .[0]) >= 69' tarpaulin-report.json
+        run: jq -e '.files | reduce .[] as $num ([0,0]; [.[0]+$num.coverable, .[1]+$num.covered]) | (.[1] * 100 / .[0]) >= 73' tarpaulin-report.json
 
   may-merge:
     needs: ["check", "test", "fmt", "clippy"]

--- a/src/idl2json_cli/src/lib.rs
+++ b/src/idl2json_cli/src/lib.rs
@@ -5,6 +5,9 @@
 #![deny(clippy::expect_used)]
 #![deny(clippy::unimplemented)]
 
+#[cfg(test)]
+mod tests;
+
 use anyhow::{anyhow, Context};
 use candid::parser::value::IDLValue;
 use candid::{parser::types::IDLType, IDLArgs, IDLProg};

--- a/src/idl2json_cli/src/lib.rs
+++ b/src/idl2json_cli/src/lib.rs
@@ -6,6 +6,7 @@
 #![deny(clippy::unimplemented)]
 
 use anyhow::{anyhow, Context};
+use candid::parser::value::IDLValue;
 use candid::{parser::types::IDLType, IDLArgs, IDLProg};
 use clap::Parser;
 use idl2json::{idl2json, idl2json_with_weak_names, polyfill, Idl2JsonOptions};
@@ -13,38 +14,48 @@ use std::{path::PathBuf, str::FromStr};
 
 /// Reads IDL from stdin, writes JSON to stdout.
 pub fn main(args: &Args, idl_str: &str) -> anyhow::Result<String> {
-    let idl_args = {
-        let idl_args: IDLArgs = idl_str
-            .parse()
-            .with_context(|| anyhow!("Malformed input"))?;
-        idl_args
+    let idl_args: IDLArgs = idl_str
+        .parse()
+        .with_context(|| anyhow!("Malformed input"))?;
+    let idl2json_options = Idl2JsonOptions::default();
+    convert_all(&idl_args, args, &idl2json_options)
+}
+
+/// Candid typically comes as a tuple of values.  This converts a single value in such a tuple.
+fn convert_one(
+    idl_value: &IDLValue,
+    args: &Args,
+    idl2json_options: &Idl2JsonOptions,
+) -> anyhow::Result<String> {
+    let json_value = if let (Some(did), Some(typ)) = (&args.did, &args.typ) {
+        let idl_type: IDLType = {
+            let prog = {
+                let did_as_str = std::fs::read_to_string(did)
+                    .with_context(|| anyhow!("Could not read did file '{}'.", did.display()))?;
+                IDLProg::from_str(&did_as_str)
+                    .with_context(|| anyhow!("Failed to parse did file '{}'", did.display()))?
+            };
+            polyfill::idl_prog::get(&prog, typ).ok_or_else(|| {
+                anyhow!("Type '{typ}' not found in .did file '{}'.", did.display())
+            })?
+        };
+        idl2json_with_weak_names(idl_value, &idl_type, idl2json_options)
+    } else {
+        idl2json(idl_value, idl2json_options)
     };
+    serde_json::to_string(&json_value).with_context(|| anyhow!("Cannot print to stderr"))
+}
+
+/// Candid typically comes as a tuple of values.  This converts all such tuples
+fn convert_all(
+    idl_args: &IDLArgs,
+    args: &Args,
+    idl2json_options: &Idl2JsonOptions,
+) -> anyhow::Result<String> {
     let json_structures: anyhow::Result<Vec<String>> = idl_args
         .args
         .iter()
-        .map(|idl_value| {
-            let idl2json_options = Idl2JsonOptions::default();
-
-            let json_value = if let (Some(did), Some(typ)) = (&args.did, &args.typ) {
-                let idl_type: IDLType = {
-                    let prog = {
-                        let did_as_str = std::fs::read_to_string(did).with_context(|| {
-                            anyhow!("Could not read did file '{}'.", did.display())
-                        })?;
-                        IDLProg::from_str(&did_as_str).with_context(|| {
-                            anyhow!("Failed to parse did file '{}'", did.display())
-                        })?
-                    };
-                    polyfill::idl_prog::get(&prog, typ).ok_or_else(|| {
-                        anyhow!("Type '{typ}' not found in .did file '{}'.", did.display())
-                    })?
-                };
-                idl2json_with_weak_names(idl_value, &idl_type, &idl2json_options)
-            } else {
-                idl2json(idl_value, &idl2json_options)
-            };
-            serde_json::to_string(&json_value).with_context(|| anyhow!("Cannot print to stderr"))
-        })
+        .map(|idl_value| convert_one(idl_value, args, idl2json_options))
         .collect();
     Ok(json_structures?.join("\n"))
 }

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -85,22 +85,31 @@ fn error_handling_should_be_correct() {
     struct TestVector {
         name: &'static str,
         stdin: &'static str,
+        args: Args,
         err: &'static str,
     }
-    let args = Args::default();
-    let vectors = [TestVector {
-        name: "Invalid candid on stdin",
-        stdin: "( this is not candid",
-        err: "Malformed input",
-    }];
+    let vectors = [
+        TestVector {
+            name: "Invalid candid on stdin",
+            stdin: "( this is not candid",
+            args: Args::default(),
+            err: "Malformed input",
+        },
+        TestVector {
+            name: "Typo in type name",
+            stdin: r#"( "perfectly valid candid" )"#,
+            args: typed_arg!("internet_identity.did", "IIInnit"),
+            err: r#"Type 'IIInnit' not found in .did file"#,
+        },
+    ];
     for (index, vector) in vectors.iter().enumerate() {
-        match main(&args, vector.stdin) {
+        match main(&vector.args, vector.stdin) {
             Ok(json) => panic!(
                 "#{index} ({}) should have caused an error but returned: {json}",
                 vector.name
             ),
             Err(err) => {
-                let error_message = format!("{err}");
+                let error_message = format!("{err:?}");
                 assert!(
                     error_message.contains(vector.err),
                     "The error message for #{index} ({}) should contain '{}': '{}'",

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -1,3 +1,9 @@
+//! Tests for idl2json_cli.
+#![warn(missing_docs)]
+#![allow(clippy::panic)]
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+
 use super::{main, Args};
 use anyhow::anyhow;
 use std::path::Path;

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -3,17 +3,29 @@ use anyhow::{anyhow, Context};
 
 #[test]
 fn simple_conversion_should_be_correct() {
-   struct TestVector {
-     stdin: &'static str, stdout: &'static str
-   }
-   let args = Args::default();
+    struct TestVector {
+        stdin: &'static str,
+        stdout: &'static str,
+    }
+    let args = Args::default();
     let vectors = [
-     TestVector{ stdin: "()", stdout: "\n" }
-     TestVector{ stdin: "( record {} )", stdout: "{}\n" }
-     TestVector{ stdin: "( record {}, record {} )", stdout: "{}\n{}\n" }
-  ];
-  for vector in vectors {
-      let out = main(&args, vector.stdin).map_err(|e| anyhow!("Failed to parse: {} due to: {e}", vector.stdin)).unwrap();
-    assert_eq!(vector.stdout, &out)
-  }
+        TestVector {
+            stdin: "()",
+            stdout: "",
+        },
+        TestVector {
+            stdin: "( record {} )",
+            stdout: "{}",
+        },
+        TestVector {
+            stdin: "( record {}, record {} )",
+            stdout: "{}\n{}",
+        },
+    ];
+    for vector in vectors {
+        let out = main(&args, vector.stdin)
+            .map_err(|e| anyhow!("Failed to parse: {} due to: {e}", vector.stdin))
+            .unwrap();
+        assert_eq!(vector.stdout, &out)
+    }
 }

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -42,7 +42,7 @@ macro_rules! sample_file {
         .to_path_buf()
     };
 }
-/// Constructs idl2json_cli arguments using a did file in the samples directory.
+/// Constructs idl2json_cli arguments using a type and a did file in the samples directory.
 macro_rules! typed_arg {
     ($did_file:literal, $typ:literal) => {
         Args {


### PR DESCRIPTION
# Motivation
The `idl2json` CLI has no tests.  A previous PR sketched in the tests but:
- The tests were not enabled
- The tests are far from complete.

# Changes
- Enable the `idl2json_cli` tests file.
- Add tests to bring the code coverage of `idl2json_cli/src/lib.rs` to 100%.  Note, not every combination of branches is covered but every line is exercised at least once.
- Ratchet up the required code coverage in CI.

# Tests
This PR provides just tests.  They are exercised in CI and the tarpaulin code coverage report is also available in CI.