### PR TITLE
Cli bytes as

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,6 +632,7 @@ name = "idl2json"
 version = "0.8.7"
 dependencies = [
  "candid 0.8.4",
+ "clap",
  "json-patch",
  "num-bigint",
  "serde",

--- a/src/idl2json/Cargo.toml
+++ b/src/idl2json/Cargo.toml
@@ -19,6 +19,7 @@ keywords = ["internet-computer", "idl", "candid", "dfinity", "json"]
 candid = "0.8.1"
 serde_json = "^1.0"
 sha2 = { version = "0.10.6", optional = true }
+clap = { version = "3", features = [ "derive" ], optional = true }
 
 [dev-dependencies]
 json-patch = "0.2.6"
@@ -28,3 +29,4 @@ num-bigint = "0.4.3"
 [features]
 default = ["crypto"]
 crypto = ["sha2"]
+clap = ["dep:clap"]

--- a/src/idl2json/src/lib.rs
+++ b/src/idl2json/src/lib.rs
@@ -39,7 +39,9 @@ pub struct Idl2JsonOptions {
 }
 
 /// Options for how to represent `Vec<u8>`
-#[derive(Copy, Clone, Eq, PartialEq, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Default, Debug)]
+#[cfg_attr(feature = "clap", derive(clap::ArgEnum))]
+#[cfg_attr(feature = "clap", clap(rename_all = "kebab_case"))]
 pub enum BytesFormat {
     /// Data is represented as an array of numbers: `[1,34,0]`
     #[default]

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -30,7 +30,11 @@ pub fn idl2json_with_weak_names(
     idl_type: &IDLType,
     options: &Idl2JsonOptions,
 ) -> JsonValue {
-    match (idl, idl_type) {
+        let mut typ_str = format!("{idl_type:?}");
+        typ_str.truncate(40);
+        let mut idl_str = format!("{idl:?}");
+        idl_str.truncate(60);
+    let ans = match (idl, idl_type) {
         (idl, IDLType::VarT(type_name)) => {
             if let Some(resolved_type) = get_type_from_any(&options.prog, type_name) {
                 idl2json_with_weak_names(idl, &resolved_type, options)
@@ -103,7 +107,11 @@ pub fn idl2json_with_weak_names(
                 .unwrap_or_else(|| JsonValue::String("NaN".to_string()))
         }
         (IDLValue::Reserved, _) => JsonValue::String(idl.to_string()),
-    }
+    };
+    let mut ans_str = format!("{ans:?}");
+    ans_str.truncate(60);
+eprintln!("{typ_str}  ==> {idl_str} ==> {ans_str}");
+ans
 }
 
 /// Returns a typed IDLField as a (key, value) pair.

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -30,11 +30,7 @@ pub fn idl2json_with_weak_names(
     idl_type: &IDLType,
     options: &Idl2JsonOptions,
 ) -> JsonValue {
-        let mut typ_str = format!("{idl_type:?}");
-        typ_str.truncate(40);
-        let mut idl_str = format!("{idl:?}");
-        idl_str.truncate(60);
-    let ans = match (idl, idl_type) {
+    match (idl, idl_type) {
         (idl, IDLType::VarT(type_name)) => {
             if let Some(resolved_type) = get_type_from_any(&options.prog, type_name) {
                 idl2json_with_weak_names(idl, &resolved_type, options)
@@ -107,11 +103,7 @@ pub fn idl2json_with_weak_names(
                 .unwrap_or_else(|| JsonValue::String("NaN".to_string()))
         }
         (IDLValue::Reserved, _) => JsonValue::String(idl.to_string()),
-    };
-    let mut ans_str = format!("{ans:?}");
-    ans_str.truncate(60);
-eprintln!("{typ_str}  ==> {idl_str} ==> {ans_str}");
-ans
+    }
 }
 
 /// Returns a typed IDLField as a (key, value) pair.

--- a/src/idl2json_cli/Cargo.toml
+++ b/src/idl2json_cli/Cargo.toml
@@ -24,7 +24,7 @@ candid = "0.8.1" # Should match the version in the lib.
 clap = { version = "3.1.6", features = [ "derive" ] }
 fn-error-context = "0.2.0"
 serde_json = "^1.0"
-idl2json = { path = "../idl2json", version = "0.8.7" }
+idl2json = { path = "../idl2json", version = "0.8.7", features = ["clap", "crypto"] }
 anyhow = "1"
 
 [build-dependencies]

--- a/src/idl2json_cli/src/lib.rs
+++ b/src/idl2json_cli/src/lib.rs
@@ -16,12 +16,13 @@ use candid::{
 };
 use clap::Parser;
 use idl2json::{
-    idl2json, idl2json_with_weak_names, idl_args2json_with_weak_names, polyfill, Idl2JsonOptions,
+    idl2json, idl2json_with_weak_names, idl_args2json_with_weak_names, polyfill, Idl2JsonOptions, BytesFormat
 };
 use std::{path::PathBuf, str::FromStr};
 
 /// Reads IDL from stdin, writes JSON to stdout.
 pub fn main(args: &Args, idl_str: &str) -> anyhow::Result<String> {
+    eprintln!("{args:?}");
     let idl_args: IDLArgs = idl_str
         .parse()
         .with_context(|| anyhow!("Malformed input"))?;
@@ -40,6 +41,7 @@ pub fn main(args: &Args, idl_str: &str) -> anyhow::Result<String> {
 
         Idl2JsonOptions {
             prog: progs,
+            bytes_as: args.bytes_as,
             ..Idl2JsonOptions::default()
         }
     };
@@ -120,4 +122,7 @@ pub struct Args {
     /// Use the service init argument type from the did file
     #[clap(short, long, requires("did"))]
     init: bool,
+    /// How to display bytes
+    #[clap(short, long, arg_enum)]
+    bytes_as: Option<BytesFormat>,
 }

--- a/src/idl2json_cli/src/lib.rs
+++ b/src/idl2json_cli/src/lib.rs
@@ -22,7 +22,6 @@ use std::{path::PathBuf, str::FromStr};
 
 /// Reads IDL from stdin, writes JSON to stdout.
 pub fn main(args: &Args, idl_str: &str) -> anyhow::Result<String> {
-    eprintln!("{args:?}");
     let idl_args: IDLArgs = idl_str
         .parse()
         .with_context(|| anyhow!("Malformed input"))?;

--- a/src/idl2json_cli/src/lib.rs
+++ b/src/idl2json_cli/src/lib.rs
@@ -16,7 +16,8 @@ use candid::{
 };
 use clap::Parser;
 use idl2json::{
-    idl2json, idl2json_with_weak_names, idl_args2json_with_weak_names, polyfill, Idl2JsonOptions, BytesFormat
+    idl2json, idl2json_with_weak_names, idl_args2json_with_weak_names, polyfill, BytesFormat,
+    Idl2JsonOptions,
 };
 use std::{path::PathBuf, str::FromStr};
 

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::expect_used)]
 
-use super::{main, Args};
+use super::{main, Args, BytesFormat};
 use anyhow::anyhow;
 use std::path::Path;
 
@@ -55,6 +55,7 @@ macro_rules! typed_arg {
             did: vec![sample_file!($did_file)],
             typ: Some($typ.to_string()),
             init: false,
+            bytes_as: Some(BytesFormat::Numbers),
         }
     };
 }
@@ -125,6 +126,7 @@ fn conversion_with_options_should_be_correct() {
                 did: vec![sample_file!("internet_identity.did")],
                 typ: None,
                 init: true,
+                bytes_as: None,
             },
             stdout: r#"[[{"canister_creation_cycles_cost":["6_974"]}]]"#,
         },


### PR DESCRIPTION
# Motivation
Proposals contain didc wrapped in didc, so they need to be parsed, then the payload bytes need to be parsed again.  `didc` takes hex as input, so the payload blob is needed as hex, not an array of ints.  The `idl2json` library already supports this, but the option is not exposed in the CLI.

# Changes
* Expose the idl2json bytes formatting option in the CLI.
  Note: The "long bytes" option is not exposed, as the clap for that is complicated and this is not a priority.