### PR TITLE
Offer compact and pretty output, with pretty being the default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "idl2json"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "candid 0.8.4",
  "clap",
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "idl2json_cli"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "candid 0.8.4",
@@ -1601,7 +1601,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "yaml2candid"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "candid 0.7.0",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "yaml2candid_cli"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "clap",
  "toml",

--- a/src/idl2json/Cargo.toml
+++ b/src/idl2json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idl2json"
-version = "0.8.8"
+version = "0.9.0"
 authors = ["dfinity <sdk@dfinity.org>"]
 edition = "2018"
 description = "Converts the candid interface description language to JSON."

--- a/src/idl2json/src/lib.rs
+++ b/src/idl2json/src/lib.rs
@@ -36,6 +36,8 @@ pub struct Idl2JsonOptions {
     ///   `idl2json` will use the first match it finds.  It is the
     ///   caller's responsibility to ensure that there are no conflicting definitions.
     pub prog: Vec<IDLProg>,
+    /// Compact JSON, without formatting whitespace.
+    pub compact: bool,
 }
 
 /// Options for how to represent `Vec<u8>`

--- a/src/idl2json_cli/Cargo.toml
+++ b/src/idl2json_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idl2json_cli"
-version = "0.8.8"
+version = "0.9.0"
 authors = ["dfinity <sdk@dfinity.org>"]
 edition = "2021"
 description = "Converts the candid interface description language to JSON."
@@ -24,7 +24,7 @@ candid = "0.8.1" # Should match the version in the lib.
 clap = { version = "3.1.6", features = [ "derive" ] }
 fn-error-context = "0.2.0"
 serde_json = "^1.0"
-idl2json = { path = "../idl2json", version = "0.8.8", features = ["clap", "crypto"] }
+idl2json = { path = "../idl2json", version = "0.9.0", features = ["clap", "crypto"] }
 anyhow = "1"
 
 [build-dependencies]

--- a/src/idl2json_cli/src/lib.rs
+++ b/src/idl2json_cli/src/lib.rs
@@ -42,6 +42,7 @@ pub fn main(args: &Args, idl_str: &str) -> anyhow::Result<String> {
         Idl2JsonOptions {
             prog: progs,
             bytes_as: args.bytes_as,
+            compact: args.compact,
             ..Idl2JsonOptions::default()
         }
     };
@@ -92,7 +93,12 @@ fn convert_one(
     } else {
         idl2json(idl_value, idl2json_options)
     };
-    serde_json::to_string(&json_value).with_context(|| anyhow!("Cannot print to stderr"))
+    (if idl2json_options.compact {
+        serde_json::to_string
+    } else {
+        serde_json::to_string_pretty
+    })(&json_value)
+    .with_context(|| anyhow!("Cannot print to stderr"))
 }
 
 /// Candid typically comes as a tuple of values.  This converts all such tuples
@@ -125,4 +131,7 @@ pub struct Args {
     /// How to display bytes
     #[clap(short, long, arg_enum)]
     bytes_as: Option<BytesFormat>,
+    /// Print compact output
+    #[clap(short, long)]
+    compact: bool,
 }

--- a/src/idl2json_cli/src/tests.rs
+++ b/src/idl2json_cli/src/tests.rs
@@ -56,6 +56,7 @@ macro_rules! typed_arg {
             typ: Some($typ.to_string()),
             init: false,
             bytes_as: Some(BytesFormat::Numbers),
+            compact: true,
         }
     };
 }
@@ -98,6 +99,7 @@ fn conversion_with_options_should_be_correct() {
             stdin: "(record { 2_138_241_783 = opt (911 : int) })",
             args: Args {
                 typ: Some("record { canister_creation_cycles_cost: nat32; }".to_string()),
+                compact: true,
                 ..Args::default()
             },
             stdout: r#"{"canister_creation_cycles_cost":["911"]}"#,
@@ -111,6 +113,7 @@ fn conversion_with_options_should_be_correct() {
             stdin: "(record { 2_138_241_783 = opt (42 : int) })",
             args: Args {
                 typ: Some("(record { canister_creation_cycles_cost: nat32; })".to_string()),
+                compact: true,
                 ..Args::default()
             },
             stdout: r#"[{"canister_creation_cycles_cost":["42"]}]"#,
@@ -127,6 +130,7 @@ fn conversion_with_options_should_be_correct() {
                 typ: None,
                 init: true,
                 bytes_as: None,
+                compact: true,
             },
             stdout: r#"[[{"canister_creation_cycles_cost":["6_974"]}]]"#,
         },

--- a/src/yaml2candid/Cargo.toml
+++ b/src/yaml2candid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaml2candid"
-version = "0.8.8"
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/yaml2candid_cli/Cargo.toml
+++ b/src/yaml2candid_cli/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "yaml2candid_cli"
-version = "0.8.8"
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 clap = { version = "3.1.6", features = [ "derive" ] }
-yaml2candid = { path = "../yaml2candid", version = "0.8.8" }
+yaml2candid = { path = "../yaml2candid", version = "0.9.0" }
 
 [build-dependencies]
 toml = "0.5.9"


### PR DESCRIPTION
# Motivation
The current compact JSON output is hard to read, frequently making an additional pipe to a formatting tool necessary.

# Changes
- Offer both pretty and compact output.
  - Note: The flag is the same as with `jq` to ease adoption:
    ```
    $ jq --help | grep comp
     -c               compact instead of pretty-printed output;
    ```