### PR TITLE
chore: Set resolver to 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,5 @@ members = [
   "src/yaml2candid",
   "src/yaml2candid_cli",
 ]
+
+resolver = "2"


### PR DESCRIPTION
# Motivation
This warning:
```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

# Changes
* Set the resolver to 2.

# Tests
Existing tests should suffice