### PR TITLE
Set the idl2json version in the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ members = [
 ]
 
 resolver = "2"
+
+[workspace.dependencies]
+candid = "0.8.1"

--- a/src/idl2json/Cargo.toml
+++ b/src/idl2json/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["internet-computer", "idl", "candid", "dfinity", "json"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-candid = "0.8.1"
+candid = { workspace = true }
 serde_json = "^1.0"
 sha2 = { version = "0.10.6", optional = true }
 clap = { version = "3", features = [ "derive" ], optional = true }

--- a/src/idl2json_cli/Cargo.toml
+++ b/src/idl2json_cli/Cargo.toml
@@ -20,7 +20,7 @@ name = "idl2json"
 path = "src/main.rs"
 
 [dependencies]
-candid = "0.8.1" # Should match the version in the lib.
+candid = { workspace = true }
 clap = { version = "3.1.6", features = [ "derive" ] }
 fn-error-context = "0.2.0"
 serde_json = "^1.0"


### PR DESCRIPTION
# Motivation
The `idl2json_cli` needs to use the same version of candid as `idl2json`.  Currently, this is enforced only by this comment:
```
candid = "0.8.1" # Should match the version in the lib.
```
We can provide a stronger guarantee that they are the same by providing the candid version in the workspace.

# Changes
- Define the candid version in the workspace Cargo.toml.
- Use the workspace candid version in `idl2json` and `idl2json_cli`, but not `yaml2candid`.  The last currently uses a different version.  Perhaps it _should_ use the same but it does not.

# Tests
Existing tests should suffice.