### PR TITLE
Update candid to 0.8.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-candid = "0.8.1"
+candid = "0.8.4"


### PR DESCRIPTION
# Motivation
A new minor release of `candid` is available.  The latest `0.8.*` release of candid is `0.8.4`, so this PR ensures that the latest and greatest `0.8.*` series `candid` is supported before we switch to `0.9.*` series releases.