### PR TITLE
Update to candid 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,18 +18,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "372baaa5d3a422d8816b513bcdb2c120078c8614f7ecbcc3baf34a1634bbbe2e"
 dependencies = [
  "abnf",
- "indexmap",
+ "indexmap 1.9.1",
  "itertools 0.9.0",
  "pretty 0.5.2",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -74,7 +65,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -111,7 +102,7 @@ dependencies = [
  "either",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -134,6 +125,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-buffer"
@@ -188,9 +185,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "candid"
-version = "0.8.4"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244005a1917bb7614cd775ca8a5d59efeb5ac74397bb14ba29a19347ebd78591"
+checksum = "749938f355699c7dd0975e505d54541cd1d84db239374470bdf500a5d885530a"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -198,6 +195,7 @@ dependencies = [
  "byteorder",
  "candid_derive",
  "codespan-reporting",
+ "convert_case",
  "crc32fast",
  "data-encoding",
  "fake",
@@ -210,25 +208,35 @@ dependencies = [
  "num-traits",
  "num_enum",
  "paste",
- "pretty 0.10.0",
+ "pretty 0.12.3",
  "rand",
  "serde",
  "serde_bytes",
  "serde_dhall",
  "sha2 0.10.6",
+ "stacker",
  "thiserror",
 ]
 
 [[package]]
 name = "candid_derive"
-version = "0.5.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f1f4db7c7d04b87b70b3a35c5dc5c2c9dd73cef8bdf6760e2f18a0d45350dd"
+checksum = "158403ea38fab5904ae47a5d67eb7047650a91681407f5ccbcbcabc4f4ffb489"
 dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -244,10 +252,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
- "indexmap",
+ "indexmap 1.9.1",
  "once_cell",
  "strsim",
  "termcolor",
@@ -264,7 +272,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -284,6 +292,15 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -322,20 +339,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.3.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "dhall"
@@ -370,7 +376,7 @@ checksum = "df7c81d16870879ef530b07cef32bc6088f98937ab4168106cc8e382a05146bf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -459,6 +465,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "fake"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,9 +508,9 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fixedbitset"
-version = "0.2.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fn-error-context"
@@ -487,7 +520,7 @@ checksum = "236b4e4ae2b8be5f7a5652f6108c4a0f2627c569db4e7923333d31c7dbfed0fb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -548,6 +581,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +600,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex"
@@ -620,7 +665,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.1",
 ]
 
 [[package]]
@@ -630,6 +685,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi 0.3.3",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -675,21 +741,21 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.19.6"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15174f1c529af5bf1283c3bc0058266b483a67156f79589fab2a25e23cf8988"
+checksum = "da4081d44f4611b66c6dd725e6de3169f9f63905421e8626fcb86b6a898998b8"
 dependencies = [
  "ascii-canvas",
- "atty",
  "bit-set",
  "diff",
  "ena",
+ "is-terminal",
  "itertools 0.10.1",
  "lalrpop-util",
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.7.5",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -698,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.6"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e58cce361efcc90ba8a0a5f982c741ff86b603495bb15a998412e957dcd278"
+checksum = "3f35c735096c0293d313e8f2a641627472b83d01b937177fe76e5e2708d31e0d"
 dependencies = [
  "regex",
 ]
@@ -724,7 +790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "ryu",
  "static_assertions",
@@ -732,9 +798,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.107"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
 name = "lock_api"
@@ -756,26 +828,34 @@ dependencies = [
 
 [[package]]
 name = "logos"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427e2abca5be13136da9afdbf874e6b34ad9001dd70f2b103b083a85daa7b345"
+checksum = "c000ca4d908ff18ac99b93a062cb8958d331c3220719c52e77cb19cc6ac5d2c1"
 dependencies = [
  "logos-derive",
 ]
 
 [[package]]
-name = "logos-derive"
-version = "0.12.0"
+name = "logos-codegen"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56a7d287fd2ac3f75b11f19a1c8a874a7d55744bd91f7a1b3e7cf87d4343c36d"
+checksum = "dc487311295e0002e452025d6b580b77bb17286de87b57138f3b5db711cded68"
 dependencies = [
  "beef",
  "fnv",
  "proc-macro2",
  "quote",
- "regex-syntax",
- "syn",
- "utf8-ranges",
+ "regex-syntax 0.6.25",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbfc0d229f1f42d790440136d941afd806bc9e949e2bcb8faa813b0f00d1267e"
+dependencies = [
+ "logos-codegen",
 ]
 
 [[package]]
@@ -840,24 +920,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9bd055fb730c4f8f4f57d45d35cd6b3f0980535b056dc7ff119cee6a66ed6f"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
 dependencies = [
- "derivative",
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486ea01961c4a818096de679a8b740b26d9033146ac5291b1c98557658f8cdd9"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -949,7 +1028,7 @@ checksum = "9d8630a7a899cb344ec1c16ba0a6b24240029af34bdc0a21f84e411d7f793f29"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -972,7 +1051,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -988,12 +1067,12 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.5.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.0.2",
 ]
 
 [[package]]
@@ -1007,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "pico-args"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "ppv-lite86"
@@ -1034,12 +1113,13 @@ dependencies = [
 
 [[package]]
 name = "pretty"
-version = "0.10.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9940b913ee56ddd94aec2d3cd179dd47068236f42a1a6415ccf9d880ce2a61"
+checksum = "b55c4d17d994b637e2f4daf6e5dc5d660d209d5642377d675d7a1c3ab69fa579"
 dependencies = [
  "arrayvec",
  "typed-arena 2.0.1",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1061,7 +1141,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
  "version_check",
 ]
 
@@ -1078,18 +1158,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -1130,7 +1219,7 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1149,9 +1238,7 @@ version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
+ "regex-syntax 0.6.25",
 ]
 
 [[package]]
@@ -1159,6 +1246,25 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "rustix"
+version = "0.38.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f9da0cbd88f9f09e7814e388301c8414c51c62aa6ce1e4b5c551d49d96e531"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustversion"
@@ -1214,7 +1320,7 @@ checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -1247,7 +1353,7 @@ version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d232d893b10de3eb7258ff01974d6ee20663d8e833263c99409d4b13a0209da"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.1",
  "itoa 1.0.4",
  "ryu",
  "serde",
@@ -1309,6 +1415,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,6 +1461,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1387,7 +1517,7 @@ checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.94",
 ]
 
 [[package]]
@@ -1463,6 +1593,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1470,6 +1606,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -1499,12 +1641,6 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "utf8-ranges"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-candid = "0.8.4"
+candid = "0.9.0"

--- a/src/idl2json/examples/init.rs
+++ b/src/idl2json/examples/init.rs
@@ -1,8 +1,5 @@
 //! Example of how to convert binary candid to JSON using a schema
-use candid::{
-    parser::{types::IDLType, value::IDLValue},
-    Decode, IDLProg,
-};
+use candid::{parser::types::IDLType, types::value::IDLValue, Decode, IDLProg};
 use idl2json::{idl2json, idl2json_with_weak_names, polyfill, Idl2JsonOptions};
 use std::str::FromStr;
 

--- a/src/idl2json/src/bytes.rs
+++ b/src/idl2json/src/bytes.rs
@@ -1,5 +1,5 @@
 use crate::{BytesFormat, Idl2JsonOptions};
-use candid::parser::value::IDLValue;
+use candid::types::value::IDLValue;
 use serde_json::value::Value as JsonValue;
 use sha2::{Digest, Sha256};
 

--- a/src/idl2json/src/candid_types.rs
+++ b/src/idl2json/src/candid_types.rs
@@ -1,7 +1,7 @@
 //! Code for manipulating candid types.
 use candid::{
     parser::types::{IDLType, PrimType, TypeField},
-    types::internal::{Field as InternalField, Type as InternalType},
+    types::internal::{Field as InternalField, Type as InternalType, TypeInner},
 };
 
 /// Deriving CandidType on a RustType provides
@@ -12,49 +12,48 @@ use candid::{
 /// but I cannot see it.
 #[allow(clippy::unimplemented)]
 pub fn internal_candid_type_to_idl_type(internal_type: &InternalType) -> IDLType {
-    match internal_type {
-        InternalType::Null => IDLType::PrimT(PrimType::Null),
-        InternalType::Bool => IDLType::PrimT(PrimType::Null),
-        InternalType::Nat => IDLType::PrimT(PrimType::Nat),
-        InternalType::Int => IDLType::PrimT(PrimType::Int),
-        InternalType::Nat8 => IDLType::PrimT(PrimType::Nat8),
-        InternalType::Nat16 => IDLType::PrimT(PrimType::Nat16),
-        InternalType::Nat32 => IDLType::PrimT(PrimType::Nat32),
-        InternalType::Nat64 => IDLType::PrimT(PrimType::Nat64),
-        InternalType::Int8 => IDLType::PrimT(PrimType::Int8),
-        InternalType::Int16 => IDLType::PrimT(PrimType::Int16),
-        InternalType::Int32 => IDLType::PrimT(PrimType::Int32),
-        InternalType::Int64 => IDLType::PrimT(PrimType::Int64),
-        InternalType::Float32 => IDLType::PrimT(PrimType::Float32),
-        InternalType::Float64 => IDLType::PrimT(PrimType::Float64),
-        InternalType::Text => IDLType::PrimT(PrimType::Text),
-        InternalType::Reserved => IDLType::PrimT(PrimType::Reserved),
-        InternalType::Empty => IDLType::PrimT(PrimType::Empty),
-        InternalType::Knot(_) => unimplemented!(),
-        InternalType::Var(_) => unimplemented!(),
-        InternalType::Unknown => unimplemented!(),
-        InternalType::Opt(boxed_type) => {
+    match internal_type.as_ref() {
+        TypeInner::Null => IDLType::PrimT(PrimType::Null),
+        TypeInner::Bool => IDLType::PrimT(PrimType::Null),
+        TypeInner::Nat => IDLType::PrimT(PrimType::Nat),
+        TypeInner::Int => IDLType::PrimT(PrimType::Int),
+        TypeInner::Nat8 => IDLType::PrimT(PrimType::Nat8),
+        TypeInner::Nat16 => IDLType::PrimT(PrimType::Nat16),
+        TypeInner::Nat32 => IDLType::PrimT(PrimType::Nat32),
+        TypeInner::Nat64 => IDLType::PrimT(PrimType::Nat64),
+        TypeInner::Int8 => IDLType::PrimT(PrimType::Int8),
+        TypeInner::Int16 => IDLType::PrimT(PrimType::Int16),
+        TypeInner::Int32 => IDLType::PrimT(PrimType::Int32),
+        TypeInner::Int64 => IDLType::PrimT(PrimType::Int64),
+        TypeInner::Float32 => IDLType::PrimT(PrimType::Float32),
+        TypeInner::Float64 => IDLType::PrimT(PrimType::Float64),
+        TypeInner::Text => IDLType::PrimT(PrimType::Text),
+        TypeInner::Reserved => IDLType::PrimT(PrimType::Reserved),
+        TypeInner::Empty => IDLType::PrimT(PrimType::Empty),
+        TypeInner::Knot(_) => unimplemented!(),
+        TypeInner::Var(_) => unimplemented!(),
+        TypeInner::Unknown => unimplemented!(),
+        TypeInner::Opt(boxed_type) => {
             IDLType::OptT(Box::new(internal_candid_type_to_idl_type(boxed_type)))
         }
-        InternalType::Vec(items) => {
-            IDLType::VecT(Box::new(internal_candid_type_to_idl_type(items)))
-        }
-        InternalType::Record(fields) => {
+        TypeInner::Vec(items) => IDLType::VecT(Box::new(internal_candid_type_to_idl_type(items))),
+        TypeInner::Record(fields) => {
             IDLType::RecordT(fields.iter().map(internal_field_type_to_idl_type).collect())
         }
-        InternalType::Variant(fields) => {
+        TypeInner::Variant(fields) => {
             IDLType::VariantT(fields.iter().map(internal_field_type_to_idl_type).collect())
         }
-        InternalType::Func(_) => unimplemented!(),
-        InternalType::Service(_) => unimplemented!(),
-        InternalType::Class(_, _) => unimplemented!(),
-        InternalType::Principal => IDLType::PrincipalT,
+        TypeInner::Func(_) => unimplemented!(),
+        TypeInner::Service(_) => unimplemented!(),
+        TypeInner::Class(_, _) => unimplemented!(),
+        TypeInner::Principal => IDLType::PrincipalT,
+        TypeInner::Future => unimplemented!(),
     }
 }
 
 fn internal_field_type_to_idl_type(field: &InternalField) -> TypeField {
     TypeField {
-        label: field.id.clone(),
+        label: (*field.id).clone(),
         typ: internal_candid_type_to_idl_type(&field.ty),
     }
 }

--- a/src/idl2json/src/test.rs
+++ b/src/idl2json/src/test.rs
@@ -5,11 +5,10 @@ use crate::{
     BytesFormat, Idl2JsonOptions, JsonValue,
 };
 use candid::{
-    parser::{
-        types::{IDLType, PrimType, TypeField},
-        value::IDLValue,
-    },
+    parser::types::IDLType,
+    parser::types::{PrimType, TypeField},
     types::internal::Label,
+    types::value::IDLValue,
     CandidType, Decode, Deserialize, IDLArgs,
 };
 use serde::Serialize;

--- a/src/idl2json/src/typed_conversion.rs
+++ b/src/idl2json/src/typed_conversion.rs
@@ -1,10 +1,8 @@
 use std::iter;
 
 use candid::{
-    parser::{
-        types::{IDLType, IDLTypes, PrimType, TypeField},
-        value::{IDLField, IDLValue},
-    },
+    parser::types::{IDLType, IDLTypes, PrimType, TypeField},
+    types::value::{IDLField, IDLValue},
     IDLArgs, IDLProg,
 };
 use serde_json::value::Value as JsonValue;

--- a/src/idl2json/src/untyped_conversion.rs
+++ b/src/idl2json/src/untyped_conversion.rs
@@ -1,4 +1,4 @@
-use candid::parser::value::IDLValue;
+use candid::types::value::IDLValue;
 use candid::IDLArgs;
 use serde_json::value::Value as JsonValue;
 

--- a/src/idl2json_cli/src/lib.rs
+++ b/src/idl2json_cli/src/lib.rs
@@ -9,7 +9,7 @@
 mod tests;
 
 use anyhow::{anyhow, Context};
-use candid::parser::value::IDLValue;
+use candid::types::value::IDLValue;
 use candid::{
     parser::types::{IDLType, IDLTypes},
     IDLArgs, IDLProg,

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -4,7 +4,7 @@
 #![deny(clippy::unwrap_used)]
 use anyhow::{anyhow, bail, Context};
 use candid::parser::types::{Dec, IDLType};
-use candid::parser::value::{IDLField, IDLValue, VariantValue};
+use candid::types::value::{IDLField, IDLValue, VariantValue};
 use candid::IDLProg;
 use serde_yaml::Value as YamlValue;
 use std::path::Path;


### PR DESCRIPTION
# Motivation
We would like to support `candid` version `0.9.*`.

# Changes
- Update `candid` to version `0.9.0`.
  - Note: Also tested locally with `candid` `0.9.0` `0.9.4` and `0.9.8`.  It probably makes sense to make a release with v `0.9.0` and another with v `0.9.8`.

# Tests
Existing tests in CI should suffice.