### PR TITLE
feat: Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # These are peer dependencies of Cargo and should not be automatically bumped
+      - dependency-name: "semver"
+      - dependency-name: "crates-io"
+    rebase-strategy: "disabled"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
# Motivation
Dependabot could take over more of the chores, such as updating GitHub actions.

# Changes
- Add a dependabot config that specifies:
  - To update Rust (cargo) dependencies weekly.
  - To update GitHub actions periodically

# Tests
This same config is used by other repositories I manage, including for example nns-dapp.