### PR TITLE
Publish GitHub release after `cargo publish` has succeeded

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,3 +175,16 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish -p "${{ matrix.package }}" --locked
+  bublish_github_release:
+    needs: ["publish_idl2json", "publish_idl2json_cli"]
+    name: Publish GitHub release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish GitHub release
+        run: |
+          GIT_TAG=${{ needs.setup.outputs.GIT_TAG }}
+          echo "Publishing release $GIT_TAG..."
+          gh release edit "$GIT_TAG" --draft=false
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,6 @@
 name: Release
 on:
   workflow_dispatch:
-    inputs:
-      prerelease:
-        description: |
-          The semantic version pre-release string.
-          E.g. in `v1.2.3-beta.2` the pre-release string is `beta.3`.
-        required: false
   push:
     tags:
       - "*"
@@ -30,11 +24,10 @@ jobs:
         run: |
           # Get the release version:
           IDL2JSON_CARGO_VERSION="$(cargo metadata --locked | jq -r '.packages[] | select(.name == "idl2json") | .version')"
-          PRERELEASE="${{ github.event.inputs.prerelease }}"
-          SEMANTIC_VERSION="${IDL2JSON_CARGO_VERSION}${PRERELEASE:+-}${PRERELEASE}"
+          SEMANTIC_VERSION="${IDL2JSON_CARGO_VERSION}"
           GIT_TAG="v$SEMANTIC_VERSION"
           (
-            for var in IDL2JSON_CARGO_VERSION PRERELEASE SEMANTIC_VERSION GIT_TAG ; do
+            for var in IDL2JSON_CARGO_VERSION SEMANTIC_VERSION GIT_TAG ; do
               echo "$var=${!var}"
             done
           ) | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,7 +176,7 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish -p "${{ matrix.package }}" --locked
   bublish_github_release:
-    needs: ["publish_idl2json", "publish_idl2json_cli"]
+    needs: ["setup", "publish_idl2json", "publish_idl2json_cli"]
     name: Publish GitHub release
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "idl2json"
-version = "0.9.3-alpha.2"
+version = "0.9.3-alpha.3"
 dependencies = [
  "candid",
  "clap",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "idl2json_cli"
-version = "0.9.3-alpha.2"
+version = "0.9.3-alpha.3"
 dependencies = [
  "anyhow",
  "candid",
@@ -1747,7 +1747,7 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "yaml2candid"
-version = "0.9.3-alpha.2"
+version = "0.9.3-alpha.3"
 dependencies = [
  "anyhow",
  "candid",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "yaml2candid_cli"
-version = "0.9.3-alpha.2"
+version = "0.9.3-alpha.3"
 dependencies = [
  "clap",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "idl2json"
-version = "0.9.3-alpha.1"
+version = "0.9.3-alpha.2"
 dependencies = [
  "candid",
  "clap",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "idl2json_cli"
-version = "0.9.3-alpha.1"
+version = "0.9.3-alpha.2"
 dependencies = [
  "anyhow",
  "candid",
@@ -1747,7 +1747,7 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "yaml2candid"
-version = "0.9.3-alpha.1"
+version = "0.9.3-alpha.2"
 dependencies = [
  "anyhow",
  "candid",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "yaml2candid_cli"
-version = "0.9.3-alpha.1"
+version = "0.9.3-alpha.2"
 dependencies = [
  "clap",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 # Note: On update, please also update the dependency versions in src/*_cli/Cargo.toml
-version = "0.9.3-alpha.2"
+version = "0.9.3-alpha.3"
 
 [workspace.dependencies]
 candid = { version = "0.9.0", features = ["parser"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 # Note: On update, please also update the dependency versions in src/*_cli/Cargo.toml
-version = "0.9.3-alpha.1"
+version = "0.9.3-alpha.2"
 
 [workspace.dependencies]
 candid = { version = "0.9.0", features = ["parser"] }

--- a/src/idl2json_cli/Cargo.toml
+++ b/src/idl2json_cli/Cargo.toml
@@ -24,7 +24,7 @@ candid = { workspace = true }
 clap = { version = "3.1.6", features = [ "derive" ] }
 fn-error-context = "0.2.1"
 serde_json = "^1.0"
-idl2json = { path = "../idl2json", version="0.9.3-alpha.1", features = ["clap", "crypto"] }
+idl2json = { path = "../idl2json", version="0.9.3-alpha.2", features = ["clap", "crypto"] }
 anyhow = "1"
 
 [build-dependencies]

--- a/src/idl2json_cli/Cargo.toml
+++ b/src/idl2json_cli/Cargo.toml
@@ -24,7 +24,7 @@ candid = { workspace = true }
 clap = { version = "3.1.6", features = [ "derive" ] }
 fn-error-context = "0.2.1"
 serde_json = "^1.0"
-idl2json = { path = "../idl2json", version="0.9.3-alpha.2", features = ["clap", "crypto"] }
+idl2json = { path = "../idl2json", version="0.9.3-alpha.3", features = ["clap", "crypto"] }
 anyhow = "1"
 
 [build-dependencies]

--- a/src/yaml2candid_cli/Cargo.toml
+++ b/src/yaml2candid_cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "3.1.6", features = [ "derive" ] }
-yaml2candid = { path = "../yaml2candid", version = "0.9.3-alpha.2" }
+yaml2candid = { path = "../yaml2candid", version = "0.9.3-alpha.3" }
 
 [build-dependencies]
 toml = "0.5.9"

--- a/src/yaml2candid_cli/Cargo.toml
+++ b/src/yaml2candid_cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "3.1.6", features = [ "derive" ] }
-yaml2candid = { path = "../yaml2candid", version = "0.9.3-alpha.1" }
+yaml2candid = { path = "../yaml2candid", version = "0.9.3-alpha.2" }
 
 [build-dependencies]
 toml = "0.5.9"


### PR DESCRIPTION
# Changes
- Make the draft GitHub release public once all other steps in the release process have succeeded.
- Bump the alpha version number

# Tests
- This release was published by this workflow: https://github.com/dfinity/idl2json/releases/tag/v0.9.3-alpha.3