### PR TITLE
Release 0.9.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,7 @@ jobs:
               echo "$var=${!var}"
             done
           ) | tee -a $GITHUB_OUTPUT
+          echo "::notice::Creating release '$GIT_TAG'..."
       - name: Dry run
         run: cargo publish -p idl2json --dry-run --locked
       - name: Tag this commit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "idl2json"
-version = "0.9.3-alpha.3"
+version = "0.9.3"
 dependencies = [
  "candid",
  "clap",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "idl2json_cli"
-version = "0.9.3-alpha.3"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "candid",
@@ -1747,7 +1747,7 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "yaml2candid"
-version = "0.9.3-alpha.3"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "candid",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "yaml2candid_cli"
-version = "0.9.3-alpha.3"
+version = "0.9.3"
 dependencies = [
  "clap",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 # Note: On update, please also update the dependency versions in src/*_cli/Cargo.toml
-version = "0.9.3-alpha.3"
+version = "0.9.3"
 
 [workspace.dependencies]
 candid = { version = "0.9.0", features = ["parser"] }

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,12 @@
+# Hacking
+
+## To create a release
+- Update the version number:
+  - in `Cargo.toml`
+  - in `src/*_cli/Cargo.toml` where the version number appears in the dependencies
+  - in `Cargo.lock` by running `cargo fetch`.
+- Create a PR & merge into main.
+  - Note: For a pre-release version you MAY release from a branch.  In that case there is no need to merge to main but you should:
+    - Set the version to `x.y.z-alpha.A` e.g. `1.2.3-alpha.1`.
+    - Wait for CI to be green
+- Run this GitHub workflow by clicking the button on the right: https://github.com/dfinity/idl2json/actions/workflows/publish.yml

--- a/src/idl2json_cli/Cargo.toml
+++ b/src/idl2json_cli/Cargo.toml
@@ -24,7 +24,7 @@ candid = { workspace = true }
 clap = { version = "3.1.6", features = [ "derive" ] }
 fn-error-context = "0.2.1"
 serde_json = "^1.0"
-idl2json = { path = "../idl2json", version="0.9.3-alpha.3", features = ["clap", "crypto"] }
+idl2json = { path = "../idl2json", version="0.9.3", features = ["clap", "crypto"] }
 anyhow = "1"
 
 [build-dependencies]

--- a/src/yaml2candid_cli/Cargo.toml
+++ b/src/yaml2candid_cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "3.1.6", features = [ "derive" ] }
-yaml2candid = { path = "../yaml2candid", version = "0.9.3-alpha.3" }
+yaml2candid = { path = "../yaml2candid", version = "0.9.3" }
 
 [build-dependencies]
 toml = "0.5.9"


### PR DESCRIPTION
# Motivation
We would like a release that uses `candid` version `0.9.x`.  The workflow and feature flags have been overhauled and tested,  so we are ready to proceed.

# Changes
- Add a `HACKING.md` file.
- Add a progress message to the release flow.
- Update the version from `0.9.3-alpha.3` to `0.9.3`.