### PR TITLE
Yaml2json types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,6 +1279,7 @@ dependencies = [
  "anyhow",
  "candid",
  "candid_parser",
+ "num-bigint",
  "serde",
  "serde_yaml",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
  "either",
  "proc-macro2",
  "quote",
- "syn 1.0.94",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -222,7 +222,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.94",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -292,6 +292,12 @@ name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -742,6 +748,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,7 +766,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.94",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -993,13 +1009,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.94"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07e33e919ebcd69113d5be0e4d70c5707004ff45188910106854f38b960df4a"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1056,7 +1072,7 @@ checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.94",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1280,6 +1296,7 @@ dependencies = [
  "candid",
  "candid_parser",
  "num-bigint",
+ "pretty_assertions",
  "serde",
  "serde_yaml",
 ]
@@ -1292,3 +1309,9 @@ dependencies = [
  "toml",
  "yaml2candid",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ version = "0.10.1"
 [workspace.dependencies]
 candid = { version = "0.10.8" }
 candid_parser = { version = "0.1.0" }
+num-bigint = { version = "0.4.5" }

--- a/src/yaml2candid/Cargo.toml
+++ b/src/yaml2candid/Cargo.toml
@@ -12,3 +12,6 @@ serde = "1"
 serde_yaml = "0.9"
 anyhow = "1"
 num-bigint = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = "1.4.0"

--- a/src/yaml2candid/Cargo.toml
+++ b/src/yaml2candid/Cargo.toml
@@ -11,3 +11,4 @@ candid_parser = { workspace = true }
 serde = "1"
 serde_yaml = "0.9"
 anyhow = "1"
+num-bigint = { workspace = true }

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -182,6 +182,10 @@ impl Yaml2Candid {
                     YamlValue::Bool(value) => Ok(IDLValue::Bool(*value)),
                     _ => bail!("Please express this value as a boolean: {data:?}"),
                 },
+                candid_parser::types::PrimType::Null => match data {
+                    YamlValue::Null => Ok(IDLValue::Null),
+                    _ => bail!("Please express this value as null: {data:?}"),
+                },
                 candid_parser::types::PrimType::Text => match data {
                     YamlValue::String(value) => Ok(IDLValue::Text(value.to_string())),
                     _ => bail!("Please express this value as a string: {data:?}"),

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -102,10 +102,26 @@ impl Yaml2Candid {
                     )?)),
                     _ => bail!("Please express this value as a number: {data:?}"),
                 },
+                candid_parser::types::PrimType::Int16 => match data {
+                    YamlValue::Number(number) => Ok(IDLValue::Int16(i16::try_from(
+                        number
+                            .as_i64()
+                            .with_context(|| "Could not parse number as u64: {number:?}")?,
+                    )?)),
+                    _ => bail!("Please express this value as a number: {data:?}"),
+                },
                 candid_parser::types::PrimType::Nat16 => match data {
                     YamlValue::Number(number) => Ok(IDLValue::Nat16(u16::try_from(
                         number
                             .as_u64()
+                            .with_context(|| "Could not parse number as u64: {number:?}")?,
+                    )?)),
+                    _ => bail!("Please express this value as a number: {data:?}"),
+                },
+                candid_parser::types::PrimType::Int32 => match data {
+                    YamlValue::Number(number) => Ok(IDLValue::Int32(i32::try_from(
+                        number
+                            .as_i64()
                             .with_context(|| "Could not parse number as u64: {number:?}")?,
                     )?)),
                     _ => bail!("Please express this value as a number: {data:?}"),
@@ -116,6 +132,14 @@ impl Yaml2Candid {
                             .as_u64()
                             .with_context(|| "Could not parse number as u64: {number:?}")?,
                     )?)),
+                    _ => bail!("Please express this value as a number: {data:?}"),
+                },
+                candid_parser::types::PrimType::Int64 => match data {
+                    YamlValue::Number(number) => Ok(IDLValue::Int64(
+                        number
+                            .as_i64()
+                            .with_context(|| "Could not parse number as u64: {number:?}")?,
+                    )),
                     _ => bail!("Please express this value as a number: {data:?}"),
                 },
                 candid_parser::types::PrimType::Nat64 => match data {

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -178,6 +178,10 @@ impl Yaml2Candid {
                     ),
                     _ => bail!("Please express integers as numbers (e.g. 5) or decimal strings (e.g. \"123\"): {data:?}"),
                 })),
+                candid_parser::types::PrimType::Bool => match data {
+                    YamlValue::Bool(value) => Ok(IDLValue::Bool(*value)),
+                    _ => bail!("Please express this value as a boolean: {data:?}"),
+                },
                 candid_parser::types::PrimType::Text => match data {
                     YamlValue::String(value) => Ok(IDLValue::Text(value.to_string())),
                     _ => bail!("Please express this value as a string: {data:?}"),

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -101,19 +101,28 @@ impl Yaml2Candid {
                     )?)),
                     _ => bail!("Please express this value as a number: {data:?}"),
                 },
+                candid_parser::types::PrimType::Nat32 => match data {
+                    YamlValue::Number(number) => Ok(IDLValue::Nat32(u32::try_from(
+                        number
+                            .as_u64()
+                            .with_context(|| "Could not parse number as u64: {number:?}")?,
+                    )?)),
+                    _ => bail!("Please express this value as a number: {data:?}"),
+                },
+                candid_parser::types::PrimType::Nat64 => match data {
+                    YamlValue::Number(number) => Ok(IDLValue::Nat64(u64::try_from(
+                        number
+                            .as_u64()
+                            .with_context(|| "Could not parse number as u64: {number:?}")?,
+                    )?)),
+                    _ => bail!("Please express this value as a number: {data:?}"),
+                },
                 _ => unimplemented!(),
             },
             _ => unimplemented!(),
         }
         /*
                 match (typ, data) {
-                    (IDLType::PrimT(candid_parser::types::PrimType::Nat32), YamlValue::Number(number)) => {
-                        Ok(IDLValue::Nat32(u32::try_from(
-                            number
-                                .as_u64()
-                                .with_context(|| "Could not parse number as u64: {number:?}")?,
-                        )?))
-                    }
                     (IDLType::PrimT(candid_parser::types::PrimType::Nat64), YamlValue::Number(number)) => {
                         Ok(IDLValue::Nat64(number.as_u64().with_context(|| {
                             "Could not parse number as u64: {number:?}"

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -206,7 +206,8 @@ impl Yaml2Candid {
                     YamlValue::String(value) => Ok(IDLValue::Text(value.to_string())),
                     _ => bail!("Please express this value as a string: {data:?}"),
                 },
-                //                _ => unimplemented!(),
+                candid_parser::types::PrimType::Reserved => Ok(IDLValue::Reserved),
+                candid_parser::types::PrimType::Empty => bail!("Cannot create an Empty type; by definition the Empty type can never occur.  https://internetcomputer.org/docs/current/references/candid-ref#type-empty"),
             },
             _ => unimplemented!(),
         }

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(clippy::panic)]
 #![deny(clippy::unwrap_used)]
 use anyhow::{anyhow, bail, Context};
-use candid::types::value::{IDLField, IDLValue, VariantValue};
+use candid::{types::value::{IDLField, IDLValue, VariantValue}, Principal};
 use candid_parser::{
     types::{Dec, IDLType},
     IDLProg,
@@ -304,7 +304,30 @@ impl Yaml2Candid {
                 eprintln!("The recommended (but rarely used) way to represent an optional value is to use a sequence with one or zero elements.");
                 Ok(IDLValue::Opt(Box::new(self.convert(typ, data)?)))
             },
+            IDLType::PrincipalT => match data {
+                YamlValue::String(value) => Ok(IDLValue::Principal(Principal::from_text(value.to_string())?)),
+                _ => bail!("Expected a string for principal type, got: {data:?}"),
+            },
+            /*
+            IDLType::FuncT(_func) => {
+                // See: https://internetcomputer.org/docs/current/references/candid-ref#type-func---
+                match data {
+                    YamlValue::Sequence(values) if values.len() == 2 => {
+                        let principal = self.convert(&IDLType::PrincipalT, &values[0])?;
+                        let name = self.convert(&IDLType::PrimT(candid_parser::types::PrimType::Text), &values[1])?;
+                        Ok(IDLValue::Func(principal, name))
+                    }
+                }
+            }*/
             //_ => unimplemented!(),
         }
     }
+/*
+    fn convert_str(data: &YamlValue) -> anyhow::Result<S> {
+        match data {
+            YamlValue::String(value) => Ok(value.to_string()),
+            _ => bail!("Expected a string, got: {data:?}"),
+        }
+    }
+     */
 }

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -186,6 +186,14 @@ impl Yaml2Candid {
                     )),
                     _ => bail!("Please express this value as a number: {data:?}"),
                 },
+                candid_parser::types::PrimType::Float64 => match data {
+                    YamlValue::Number(number) => Ok(IDLValue::Float64(
+                        number
+                            .as_f64()
+                            .with_context(|| "Could not parse number as f64: {number:?}")?,
+                    )),
+                    _ => bail!("Please express this value as a number: {data:?}"),
+                },
                 candid_parser::types::PrimType::Bool => match data {
                     YamlValue::Bool(value) => Ok(IDLValue::Bool(*value)),
                     _ => bail!("Please express this value as a boolean: {data:?}"),

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -26,7 +26,10 @@ impl Default for Yaml2Candid {
     /// Creates a Yaml2Candid converter with no types.
     fn default() -> Self {
         Yaml2Candid {
-            prog: IDLProg { decs: vec![], actor: None},
+            prog: IDLProg {
+                decs: vec![],
+                actor: None,
+            },
         }
     }
 }

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -14,11 +14,21 @@ use candid_parser::{
 use num_bigint::{BigInt, BigUint};
 use serde_yaml::Value as YamlValue;
 use std::path::Path;
+#[cfg(test)]
+mod test;
 
 /// Converts YAML to Candid using a given did file.
 pub struct Yaml2Candid {
     /// The types that the converter supports, defined in an IDLProg interface definition.
     pub prog: IDLProg,
+}
+impl Default for Yaml2Candid {
+    /// Creates a Yaml2Candid converter with no types.
+    fn default() -> Self {
+        Yaml2Candid {
+            prog: IDLProg { decs: vec![], actor: None},
+        }
+    }
 }
 impl Yaml2Candid {
     /// Utility that creates a Yaml2Candid converter from the did file at the given path.

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -106,7 +106,7 @@ impl Yaml2Candid {
                     YamlValue::Number(number) => Ok(IDLValue::Int8(i8::try_from(
                         number
                             .as_i64()
-                            .with_context(|| "Could not parse number as u64: {number:?}")?,
+                            .with_context(|| "Could not parse number as i64: {number:?}")?,
                     )?)),
                     _ => bail!("Please express this value as a number: {data:?}"),
                 },
@@ -122,7 +122,7 @@ impl Yaml2Candid {
                     YamlValue::Number(number) => Ok(IDLValue::Int16(i16::try_from(
                         number
                             .as_i64()
-                            .with_context(|| "Could not parse number as u64: {number:?}")?,
+                            .with_context(|| "Could not parse number as i64: {number:?}")?,
                     )?)),
                     _ => bail!("Please express this value as a number: {data:?}"),
                 },
@@ -138,7 +138,7 @@ impl Yaml2Candid {
                     YamlValue::Number(number) => Ok(IDLValue::Int32(i32::try_from(
                         number
                             .as_i64()
-                            .with_context(|| "Could not parse number as u64: {number:?}")?,
+                            .with_context(|| "Could not parse number as i64: {number:?}")?,
                     )?)),
                     _ => bail!("Please express this value as a number: {data:?}"),
                 },
@@ -154,7 +154,7 @@ impl Yaml2Candid {
                     YamlValue::Number(number) => Ok(IDLValue::Int64(
                         number
                             .as_i64()
-                            .with_context(|| "Could not parse number as u64: {number:?}")?,
+                            .with_context(|| "Could not parse number as i64: {number:?}")?,
                     )),
                     _ => bail!("Please express this value as a number: {data:?}"),
                 },

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -86,6 +86,14 @@ impl Yaml2Candid {
                 self.convert(&typ, data)
             }
             IDLType::PrimT(prim_t) => match prim_t {
+                candid_parser::types::PrimType::Int8 => match data {
+                    YamlValue::Number(number) => Ok(IDLValue::Int8(i8::try_from(
+                        number
+                            .as_i64()
+                            .with_context(|| "Could not parse number as u64: {number:?}")?,
+                    )?)),
+                    _ => bail!("Please express this value as a number: {data:?}"),
+                },
                 candid_parser::types::PrimType::Nat8 => match data {
                     YamlValue::Number(number) => Ok(IDLValue::Nat8(u8::try_from(
                         number
@@ -150,15 +158,12 @@ impl Yaml2Candid {
                     YamlValue::String(value) => Ok(IDLValue::Text(value.to_string())),
                     _ => bail!("Please express this value as a string: {data:?}"),
                 },
-                                _ => unimplemented!(),
+                //                _ => unimplemented!(),
             },
             _ => unimplemented!(),
         }
         /*
                 match (typ, data) {
-                    (IDLType::PrincipalT, YamlValue::String(value)) => {
-                        Ok(IDLValue::Principal(candid::Principal::from_text(value)?))
-                    }
                     (IDLType::RecordT(fields), YamlValue::Mapping(mapping)) => Ok(IDLValue::Record(
                         fields
                             .iter()

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -178,6 +178,14 @@ impl Yaml2Candid {
                     ),
                     _ => bail!("Please express integers as numbers (e.g. 5) or decimal strings (e.g. \"123\"): {data:?}"),
                 })),
+                candid_parser::types::PrimType::Float32 => match data {
+                    YamlValue::Number(number) => Ok(IDLValue::Float32(
+                        number
+                            .as_f64().map(|val| val as f32)
+                            .with_context(|| "Could not parse number as f64: {number:?}")?,
+                    )),
+                    _ => bail!("Please express this value as a number: {data:?}"),
+                },
                 candid_parser::types::PrimType::Bool => match data {
                     YamlValue::Bool(value) => Ok(IDLValue::Bool(*value)),
                     _ => bail!("Please express this value as a boolean: {data:?}"),

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -123,11 +123,6 @@ impl Yaml2Candid {
         }
         /*
                 match (typ, data) {
-                    (IDLType::PrimT(candid_parser::types::PrimType::Nat64), YamlValue::Number(number)) => {
-                        Ok(IDLValue::Nat64(number.as_u64().with_context(|| {
-                            "Could not parse number as u64: {number:?}"
-                        })?))
-                    }
                     (IDLType::PrimT(candid_parser::types::PrimType::Text), YamlValue::String(value)) => {
                         Ok(IDLValue::Text(value.to_string()))
                     }

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -3,7 +3,10 @@
 #![deny(clippy::panic)]
 #![deny(clippy::unwrap_used)]
 use anyhow::{anyhow, bail, Context};
-use candid::{types::value::{IDLField, IDLValue, VariantValue}, Principal};
+use candid::{
+    types::value::{IDLField, IDLValue, VariantValue},
+    Principal,
+};
 use candid_parser::{
     types::{Dec, IDLType},
     IDLProg,
@@ -316,7 +319,14 @@ impl Yaml2Candid {
                     _ => bail!("Expected a sequence of length 2 (principal, name) for func type, got: {data:?}"),
                 }
             }
-            //_ => unimplemented!(),
+            IDLType::ServT(_bindings) => {
+                // See: https://internetcomputer.org/docs/current/references/candid-ref#type-service-
+                todo!("Conversion of service type is not supported yet.")
+            }
+            IDLType::ClassT(_, _) => {
+                // Not defined here: https://internetcomputer.org/docs/current/references/candid-ref
+                todo!("Conversion of class type is not supported yet.")
+            }
         }
     }
     fn parse_string(data: &YamlValue) -> anyhow::Result<String> {
@@ -331,7 +341,7 @@ impl Yaml2Candid {
             _ => bail!("Expected a string for principal type, got: {data:?}"),
         }
     }
-/*
+    /*
     fn convert_str(data: &YamlValue) -> anyhow::Result<S> {
         match data {
             YamlValue::String(value) => Ok(value.to_string()),

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -268,8 +268,5 @@ impl Yaml2Candid {
             },
             _ => unimplemented!(),
         }
-        /*
-                match (typ, data) {
-        */
     }
 }

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -329,24 +329,18 @@ impl Yaml2Candid {
             }
         }
     }
+    /// Gets a string from a YAML value.
     fn parse_string(data: &YamlValue) -> anyhow::Result<String> {
         match data {
             YamlValue::String(value) => Ok(value.to_string()),
             _ => bail!("Expected a string, got: {data:?}"),
         }
     }
+    /// Gets a principal from a YAML value.
     fn parse_principal(data: &YamlValue) -> anyhow::Result<Principal> {
         match data {
-            YamlValue::String(value) => Ok(Principal::from_text(value.to_string())?),
+            YamlValue::String(value) => Ok(Principal::from_text(value)?),
             _ => bail!("Expected a string for principal type, got: {data:?}"),
         }
     }
-    /*
-    fn convert_str(data: &YamlValue) -> anyhow::Result<S> {
-        match data {
-            YamlValue::String(value) => Ok(value.to_string()),
-            _ => bail!("Expected a string, got: {data:?}"),
-        }
-    }
-     */
 }

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -91,7 +91,15 @@ impl Yaml2Candid {
                             .as_u64()
                             .with_context(|| "Could not parse number as u64: {number:?}")?,
                     )?)),
-                    _ => bail!("Could not convert to Nat8: {data:?}"),
+                    _ => bail!("Please express this value as a number: {data:?}"),
+                },
+                candid_parser::types::PrimType::Nat16 => match data {
+                    YamlValue::Number(number) => Ok(IDLValue::Nat16(u16::try_from(
+                        number
+                            .as_u64()
+                            .with_context(|| "Could not parse number as u64: {number:?}")?,
+                    )?)),
+                    _ => bail!("Please express this value as a number: {data:?}"),
                 },
                 _ => unimplemented!(),
             },
@@ -99,14 +107,6 @@ impl Yaml2Candid {
         }
         /*
                 match (typ, data) {
-                    (IDLType::PrimT(candid_parser::types::PrimType::Nat8), YamlValue::Number(number)) =>
-                    (IDLType::PrimT(candid_parser::types::PrimType::Nat16), YamlValue::Number(number)) => {
-                        Ok(IDLValue::Nat16(u16::try_from(
-                            number
-                                .as_u64()
-                                .with_context(|| "Could not parse number as u64: {number:?}")?,
-                        )?))
-                    }
                     (IDLType::PrimT(candid_parser::types::PrimType::Nat32), YamlValue::Number(number)) => {
                         Ok(IDLValue::Nat32(u32::try_from(
                             number

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -305,17 +305,17 @@ impl Yaml2Candid {
                 Ok(IDLValue::Opt(Box::new(self.convert(typ, data)?)))
             },
             IDLType::PrincipalT => Ok(IDLValue::Principal(Self::parse_principal(data)?)),
-            /*
             IDLType::FuncT(_func) => {
                 // See: https://internetcomputer.org/docs/current/references/candid-ref#type-func---
                 match data {
                     YamlValue::Sequence(values) if values.len() == 2 => {
-                        let principal = self.convert(&IDLType::PrincipalT, &values[0])?;
-                        let name = self.convert(&IDLType::PrimT(candid_parser::types::PrimType::Text), &values[1])?;
+                        let principal = Self::parse_principal(&values[0])?;
+                        let name = Self::parse_string(&values[1])?;
                         Ok(IDLValue::Func(principal, name))
-                    }
+                    },
+                    _ => bail!("Expected a sequence of length 2 (principal, name) for func type, got: {data:?}"),
                 }
-            }*/
+            }
             //_ => unimplemented!(),
         }
     }

--- a/src/yaml2candid/src/lib.rs
+++ b/src/yaml2candid/src/lib.rs
@@ -304,10 +304,7 @@ impl Yaml2Candid {
                 eprintln!("The recommended (but rarely used) way to represent an optional value is to use a sequence with one or zero elements.");
                 Ok(IDLValue::Opt(Box::new(self.convert(typ, data)?)))
             },
-            IDLType::PrincipalT => match data {
-                YamlValue::String(value) => Ok(IDLValue::Principal(Principal::from_text(value.to_string())?)),
-                _ => bail!("Expected a string for principal type, got: {data:?}"),
-            },
+            IDLType::PrincipalT => Ok(IDLValue::Principal(Self::parse_principal(data)?)),
             /*
             IDLType::FuncT(_func) => {
                 // See: https://internetcomputer.org/docs/current/references/candid-ref#type-func---
@@ -320,6 +317,18 @@ impl Yaml2Candid {
                 }
             }*/
             //_ => unimplemented!(),
+        }
+    }
+    fn parse_string(data: &YamlValue) -> anyhow::Result<String> {
+        match data {
+            YamlValue::String(value) => Ok(value.to_string()),
+            _ => bail!("Expected a string, got: {data:?}"),
+        }
+    }
+    fn parse_principal(data: &YamlValue) -> anyhow::Result<Principal> {
+        match data {
+            YamlValue::String(value) => Ok(Principal::from_text(value.to_string())?),
+            _ => bail!("Expected a string for principal type, got: {data:?}"),
         }
     }
 /*

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -264,3 +264,23 @@ fn conversion_to_f32_should_fail_for_some_inputs() {
         assert_conversion_fails(&converter, &typ, data);
     }
 }
+
+#[test]
+fn can_convert_f64() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Float64);
+    for value in [0f64, -0.125, 0.5, f64::MAX, f64::MIN].iter() {
+        let data = YamlValue::from(*value);
+        let expected_result = IDLValue::Float64(*value);
+        assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}
+
+#[test]
+fn conversion_to_f64_should_fail_for_some_inputs() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Float64);
+    for data in [YamlValue::from("FOO")].iter() {
+        assert_conversion_fails(&converter, &typ, data);
+    }
+}

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -17,3 +17,14 @@ fn can_convert_i8() {
         assert_conversion_is(&converter, &typ, &data, expected_result);
     }
 }
+
+#[cfg(test)]
+fn can_convert_u8() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat8);
+    for value in [0, 1, u8::MAX].iter() {
+        let data = YamlValue::from(*value);
+        let expected_result = IDLValue::Nat8(*value);
+        assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -244,3 +244,23 @@ fn conversion_to_int_should_fail_for_some_inputs() {
         assert_conversion_fails(&converter, &typ, data);
     }
 }
+
+#[test]
+fn can_convert_f32() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Float32);
+    for value in [0f32, -0.125, 0.5, f32::MAX, f32::MIN].iter() {
+        let data = YamlValue::from(*value);
+        let expected_result = IDLValue::Float32(*value);
+        assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}
+
+#[test]
+fn conversion_to_f32_should_fail_for_some_inputs() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat64);
+    for data in [YamlValue::from(f64::MAX), YamlValue::from("FOO")].iter() {
+        assert_conversion_fails(&converter, &typ, data);
+    }
+}

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -7,8 +7,10 @@ fn assert_conversion_is(
     data: &YamlValue,
     expected_result: IDLValue,
 ) {
-    let result = converter.convert(typ, data).unwrap();
-    assert_eq!(result, expected_result);
+    let value = converter
+        .convert(typ, data)
+        .expect("Failed to convert YAML to Candid.");
+    assert_eq!(value, expected_result);
 }
 
 fn assert_conversion_fails(converter: &Yaml2Candid, typ: &IDLType, data: &YamlValue) {
@@ -35,7 +37,7 @@ fn conversion_to_i8_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Int8);
     for data in [YamlValue::from("foo"), YamlValue::from(i64::MAX)].iter() {
-        assert_conversion_fails(&converter, &typ, &data);
+        assert_conversion_fails(&converter, &typ, data);
     }
 }
 
@@ -55,7 +57,7 @@ fn conversion_to_u8_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat8);
     for data in [YamlValue::from("foo"), YamlValue::from(i64::MAX)].iter() {
-        assert_conversion_fails(&converter, &typ, &data);
+        assert_conversion_fails(&converter, &typ, data);
     }
 }
 
@@ -75,7 +77,7 @@ fn conversion_to_i16_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Int16);
     for data in [YamlValue::from("foo"), YamlValue::from(i64::MAX)].iter() {
-        assert_conversion_fails(&converter, &typ, &data);
+        assert_conversion_fails(&converter, &typ, data);
     }
 }
 
@@ -95,7 +97,7 @@ fn conversion_to_u16_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat16);
     for data in [YamlValue::from("foo"), YamlValue::from(i64::MAX)].iter() {
-        assert_conversion_fails(&converter, &typ, &data);
+        assert_conversion_fails(&converter, &typ, data);
     }
 }
 
@@ -115,7 +117,7 @@ fn conversion_to_i32_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Int32);
     for data in [YamlValue::from("foo"), YamlValue::from(i64::MAX)].iter() {
-        assert_conversion_fails(&converter, &typ, &data);
+        assert_conversion_fails(&converter, &typ, data);
     }
 }
 
@@ -135,7 +137,7 @@ fn conversion_to_u32_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat32);
     for data in [YamlValue::from("foo"), YamlValue::from(i64::MAX)].iter() {
-        assert_conversion_fails(&converter, &typ, &data);
+        assert_conversion_fails(&converter, &typ, data);
     }
 }
 
@@ -155,7 +157,7 @@ fn conversion_to_i64_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Int64);
     for data in [YamlValue::from("foo"), YamlValue::from(u64::MAX)].iter() {
-        assert_conversion_fails(&converter, &typ, &data);
+        assert_conversion_fails(&converter, &typ, data);
     }
 }
 
@@ -175,6 +177,6 @@ fn conversion_to_u64_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat8);
     for data in [YamlValue::from("foo"), YamlValue::from(-1)].iter() {
-        assert_conversion_fails(&converter, &typ, &data);
+        assert_conversion_fails(&converter, &typ, data);
     }
 }

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -338,8 +338,8 @@ fn can_convert_f32() {
 #[test]
 fn conversion_to_f32_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
-    let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat64);
-    for data in [YamlValue::from(f64::MAX), YamlValue::from("FOO")].iter() {
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Float32);
+    for data in [YamlValue::Null, YamlValue::from("FOO")].iter() {
         assert_conversion_fails(&converter, &typ, data);
     }
 }

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -494,7 +494,7 @@ fn can_convert() {
             }]),
         },
         TestVec {
-            description: "Record containing Some(5) in canonical form",
+            description: "Record containing Some(8) in canonical form",
             typ: IDLType::RecordT(vec![TypeField {
                 label: Label::Named("Foo".to_string()),
                 typ: IDLType::OptT(Box::new(IDLType::PrimT(
@@ -515,7 +515,7 @@ fn can_convert() {
             }]),
         },
         TestVec {
-            description: "Record containing Some(5) in conventional form",
+            description: "Record containing Some(8) in conventional form",
             typ: IDLType::RecordT(vec![TypeField {
                 label: Label::Named("Foo".to_string()),
                 typ: IDLType::OptT(Box::new(IDLType::PrimT(
@@ -533,7 +533,7 @@ fn can_convert() {
             }]),
         },
         TestVec {
-            description: "Record containing Some([5]) in conventional form",
+            description: "Record containing Some([8]) in conventional form",
             typ: IDLType::RecordT(vec![TypeField {
                 label: Label::Named("Foo".to_string()),
                 typ: IDLType::OptT(Box::new(IDLType::VecT(Box::new(IDLType::PrimT(
@@ -551,6 +551,30 @@ fn can_convert() {
             expected_result: IDLValue::Record(vec![IDLField {
                 id: Label::Named("Foo".to_string()),
                 val: IDLValue::Opt(Box::new(IDLValue::Vec(vec![IDLValue::Int8(8)]))),
+            }]),
+        },
+        TestVec {
+            description: "Record containing Some([5,6]) in conventional form",
+            typ: IDLType::RecordT(vec![TypeField {
+                label: Label::Named("Foo".to_string()),
+                typ: IDLType::OptT(Box::new(IDLType::VecT(Box::new(IDLType::PrimT(
+                    candid_parser::types::PrimType::Int8,
+                ))))),
+            }]),
+            data: YamlValue::Mapping(
+                [(
+                    YamlValue::from("Foo"),
+                    YamlValue::Sequence(vec![YamlValue::from(5), YamlValue::from(6)]),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            expected_result: IDLValue::Record(vec![IDLField {
+                id: Label::Named("Foo".to_string()),
+                val: IDLValue::Opt(Box::new(IDLValue::Vec(vec![
+                    IDLValue::Int8(5),
+                    IDLValue::Int8(6),
+                ]))),
             }]),
         },
     ];

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -312,3 +312,33 @@ fn conversion_to_bool_should_fail_for_some_inputs() {
         assert_conversion_fails(&converter, &typ, data);
     }
 }
+
+struct TestVec {
+    description: &'static str,
+    typ: IDLType,
+    data: YamlValue,
+    expected_result: IDLValue,
+}
+
+#[test]
+fn can_convert() {
+    let converter = Yaml2Candid::default();
+    let test_vectors = vec![
+        TestVec {
+            description: "Vector of u8s",
+            typ: IDLType::VecT(Box::new(IDLType::PrimT(candid_parser::types::PrimType::Int8))),
+            data: YamlValue::Sequence(vec![YamlValue::from(1), YamlValue::from(2), YamlValue::from(3)]),
+            expected_result: IDLValue::Vec(vec![IDLValue::Int8(1), IDLValue::Int8(2), IDLValue::Int8(3)]),
+        },
+        TestVec {
+            description: "Some(5) in canonical form",
+            typ: IDLType::OptT(Box::new(IDLType::PrimT(candid_parser::types::PrimType::Int8))),
+            data: YamlValue::Sequence(vec![YamlValue::from(5)]),
+            expected_result: IDLValue::Opt(Box::new(IDLValue::Int8(5))),
+        },
+    ];
+
+    for TestVec{description: _, typ, data, expected_result} in test_vectors.into_iter() {
+        assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -50,3 +50,24 @@ fn can_convert_u16() {
         assert_conversion_is(&converter, &typ, &data, expected_result);
     }
 }
+#[cfg(test)]
+fn can_convert_i32() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Int32);
+    for value in [i32::MIN, -1, 0, 1, i32::MAX].iter() {
+        let data = YamlValue::from(*value);
+        let expected_result = IDLValue::Int32(*value);
+        assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}
+
+#[cfg(test)]
+fn can_convert_u32() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat32);
+    for value in [0, 1, u32::MAX].iter() {
+        let data = YamlValue::from(*value);
+        let expected_result = IDLValue::Nat32(*value);
+        assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -1,5 +1,5 @@
 //! Tests converting from YAML to Candid.
-use num_bigint::BigUint;
+use num_bigint::{BigInt, BigUint};
 
 use super::{IDLType, IDLValue, Yaml2Candid, YamlValue};
 
@@ -210,6 +210,37 @@ fn conversion_to_nat_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat64);
     for data in [YamlValue::from("foo"), YamlValue::from(-1)].iter() {
+        assert_conversion_fails(&converter, &typ, data);
+    }
+}
+
+#[test]
+fn can_convert_small_ints() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Int);
+    for value in [i64::MIN, i64::MIN + 1, -1, 0, 1, i64::MAX - 1, i64::MAX].iter() {
+        let data = YamlValue::from(*value);
+        let expected_result = IDLValue::Int(candid::Int(BigInt::from(*value)));
+        assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}
+
+#[test]
+fn can_convert_large_ints_from_strings() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Int);
+    for value in ["-123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890","-1","0", "1", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"].iter() {
+        let data = YamlValue::from(*value);
+        let expected_result = IDLValue::Int(candid::Int(value.parse().unwrap()));
+        assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}
+
+#[test]
+fn conversion_to_int_should_fail_for_some_inputs() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat64);
+    for data in [YamlValue::from("foo"), YamlValue::Null].iter() {
         assert_conversion_fails(&converter, &typ, data);
     }
 }

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -1,0 +1,19 @@
+//! Tests converting from YAML to Candid.
+use super::{Yaml2Candid, IDLType, IDLValue, YamlValue};
+
+fn assert_conversion_is(converter: &Yaml2Candid, typ: &IDLType, data: &YamlValue, expected_result: IDLValue) {
+    let result = converter.convert(typ, data).unwrap();
+    assert_eq!(result, expected_result);
+}
+
+
+#[cfg(test)]
+fn can_convert_i8() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Int8);
+    for value in [i8::MIN, -1, 0, 1, i8::MAX].iter() {
+        let data = YamlValue::from(*value);
+        let expected_result = IDLValue::Int8(*value);
+        assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -1,4 +1,4 @@
-//! Tests converting from YAML to Candid.
+//! Tests converting from YAML to Candid, especially extreme values of primitive types.
 use num_bigint::{BigInt, BigUint};
 
 use super::{IDLType, IDLValue, Yaml2Candid, YamlValue};

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -577,6 +577,19 @@ fn can_convert() {
                 ]))),
             }]),
         },
+        TestVec {
+            description: "Function pointer",
+            typ: IDLType::FuncT(candid_parser::types::FuncType {
+                modes: vec![],
+                args: vec![IDLType::PrimT(candid_parser::types::PrimType::Int8)],
+                rets: vec![IDLType::PrimT(candid_parser::types::PrimType::Int8)],
+            }),
+            data: YamlValue::Sequence(vec![
+                YamlValue::from("2vxsx-fae"),
+                YamlValue::from("my_fun"),
+            ]),
+            expected_result: IDLValue::Func(candid::Principal::anonymous(), "my_fun".to_string()),
+        },
     ];
 
     for TestVec {

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -376,25 +376,6 @@ fn can_convert_bool() {
 }
 
 #[test]
-fn can_convert_null() {
-    let converter = Yaml2Candid::default();
-    let typ = IDLType::PrimT(candid_parser::types::PrimType::Null);
-    let data = YamlValue::Null;
-    let expected_result = IDLValue::Null;
-    assert_conversion_is(&converter, &typ, &data, expected_result);
-}
-
-#[test]
-fn can_convert_reserved() {
-    let converter = Yaml2Candid::default();
-    let typ = IDLType::PrimT(candid_parser::types::PrimType::Reserved);
-    for data in [YamlValue::Null, YamlValue::from("foo"), YamlValue::from(6)].iter() {
-        let expected_result = IDLValue::Reserved;
-        assert_conversion_is(&converter, &typ, data, expected_result);
-    }
-}
-
-#[test]
 fn conversion_to_bool_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Bool);
@@ -408,6 +389,62 @@ fn conversion_to_bool_should_fail_for_some_inputs() {
     .iter()
     {
         assert_conversion_fails(&converter, &typ, data);
+    }
+}
+
+#[test]
+fn can_convert_null() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Null);
+    let data = YamlValue::Null;
+    let expected_result = IDLValue::Null;
+    assert_conversion_is(&converter, &typ, &data, expected_result);
+}
+
+#[test]
+fn conversion_to_null_should_fail_for_some_inputs() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Null);
+    for data in [
+        YamlValue::from(0),
+        YamlValue::from(1),
+        YamlValue::from("FOO"),
+        YamlValue::Bool(false),
+        YamlValue::Bool(true),
+    ]
+    .iter()
+    {
+        assert_conversion_fails(&converter, &typ, data);
+    }
+}
+
+#[test]
+fn can_convert_string() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Text);
+    for value in ["", "foo", "bar", "baz"].iter() {
+        let data = YamlValue::from(*value);
+        let expected_result = IDLValue::Text(value.to_string());
+        assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}
+
+#[test]
+fn conversion_to_string_should_fail_for_some_inputs() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Text);
+    for data in [YamlValue::from(0), YamlValue::Bool(false), YamlValue::Null].iter() {
+        assert_conversion_fails(&converter, &typ, data);
+    }
+}
+
+#[test]
+fn can_convert_reserved() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Reserved);
+    for data in [YamlValue::Null, YamlValue::from("foo"), YamlValue::from(6)].iter() {
+        let expected_result = IDLValue::Reserved;
+        assert_conversion_is(&converter, &typ, data, expected_result);
     }
 }
 

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -1,10 +1,9 @@
 //! Tests converting from YAML to Candid, especially extreme values of primitive types.
-use std::collections::HashMap;
-
 use anyhow::Context;
 use candid::types::{value::IDLField, Label};
 use candid_parser::types::TypeField;
 use num_bigint::{BigInt, BigUint};
+use pretty_assertions::assert_eq;
 
 use super::{IDLType, IDLValue, Yaml2Candid, YamlValue};
 
@@ -381,6 +380,24 @@ fn can_convert() {
             expected_result: IDLValue::Record(vec![IDLField {
                 id: Label::Named("Foo".to_string()),
                 val: IDLValue::Int8(8),
+            }]),
+        },
+        TestVec {
+            description: "Record containing None in canonical form",
+            typ: IDLType::RecordT(vec![TypeField {
+                label: Label::Named("Foo".to_string()),
+                typ: IDLType::OptT(Box::new(IDLType::PrimT(
+                    candid_parser::types::PrimType::Int8,
+                ))),
+            }]),
+            data: YamlValue::Mapping(
+                [(YamlValue::from("Foo"), YamlValue::Sequence(vec![]))]
+                    .into_iter()
+                    .collect(),
+            ),
+            expected_result: IDLValue::Record(vec![IDLField {
+                id: Label::Named("Foo".to_string()),
+                val: IDLValue::None,
             }]),
         },
         TestVec {

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -218,7 +218,7 @@ fn can_convert_large_unsigned_ints_from_strings() {
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat);
     for value in ["0", "1", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"].iter() {
         let data = YamlValue::from(*value);
-        let expected_result = IDLValue::Nat(candid::Nat(value.parse().unwrap()));
+        let expected_result = IDLValue::Nat(candid::Nat(value.parse().expect("Test error: String used in test is not a valid BigUint.")));
         assert_conversion_is(&converter, &typ, &data, expected_result);
     }
 }
@@ -249,7 +249,7 @@ fn can_convert_large_ints_from_strings() {
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Int);
     for value in ["-123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890","-1","0", "1", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"].iter() {
         let data = YamlValue::from(*value);
-        let expected_result = IDLValue::Int(candid::Int(value.parse().unwrap()));
+        let expected_result = IDLValue::Int(candid::Int(value.parse().expect("Test error: String used in test is not a valid BigInt.")));
         assert_conversion_is(&converter, &typ, &data, expected_result);
     }
 }
@@ -298,7 +298,7 @@ fn can_convert_f64() {
 fn conversion_to_f64_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Float64);
-    for data in [YamlValue::from("FOO")].iter() {
+    for data in [YamlValue::from("FOO"), YamlValue::Null].iter() {
         assert_conversion_fails(&converter, &typ, data);
     }
 }
@@ -430,6 +430,6 @@ fn can_convert() {
         expected_result,
     } in test_vectors.into_iter()
     {
-        assert_named_conversion_is(&converter, &typ, &data, expected_result, &description);
+        assert_named_conversion_is(&converter, &typ, &data, expected_result, description);
     }
 }

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -6,6 +6,10 @@ fn assert_conversion_is(converter: &Yaml2Candid, typ: &IDLType, data: &YamlValue
     assert_eq!(result, expected_result);
 }
 
+fn assert_conversion_fails(converter: &Yaml2Candid, typ: &IDLType, data: &YamlValue) {
+    let result = converter.convert(typ, data);
+    assert!(result.is_err(), "Converting {data:?} to {typ:?} should fail.");
+}
 
 #[test]
 fn can_convert_i8() {
@@ -15,6 +19,15 @@ fn can_convert_i8() {
         let data = YamlValue::from(*value);
         let expected_result = IDLValue::Int8(*value);
         assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}
+
+#[test]
+fn conversion_to_i8_should_fail_for_some_inputs() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Int8);
+    for data in [YamlValue::from("foo"), YamlValue::from(i64::MAX)].iter() {
+        assert_conversion_fails(&converter, &typ, &data);
     }
 }
 
@@ -30,6 +43,15 @@ fn can_convert_u8() {
 }
 
 #[test]
+fn conversion_to_u8_should_fail_for_some_inputs() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat8);
+    for data in [YamlValue::from("foo"), YamlValue::from(i64::MAX)].iter() {
+        assert_conversion_fails(&converter, &typ, &data);
+    }
+}
+
+#[test]
 fn can_convert_i16() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Int16);
@@ -37,6 +59,15 @@ fn can_convert_i16() {
         let data = YamlValue::from(*value);
         let expected_result = IDLValue::Int16(*value);
         assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}
+
+#[test]
+fn conversion_to_i16_should_fail_for_some_inputs() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Int16);
+    for data in [YamlValue::from("foo"), YamlValue::from(i64::MAX)].iter() {
+        assert_conversion_fails(&converter, &typ, &data);
     }
 }
 
@@ -50,6 +81,16 @@ fn can_convert_u16() {
         assert_conversion_is(&converter, &typ, &data, expected_result);
     }
 }
+
+#[test]
+fn conversion_to_u16_should_fail_for_some_inputs() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat16);
+    for data in [YamlValue::from("foo"), YamlValue::from(i64::MAX)].iter() {
+        assert_conversion_fails(&converter, &typ, &data);
+    }
+}
+
 #[test]
 fn can_convert_i32() {
     let converter = Yaml2Candid::default();
@@ -62,6 +103,15 @@ fn can_convert_i32() {
 }
 
 #[test]
+fn conversion_to_i32_should_fail_for_some_inputs() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Int32);
+    for data in [YamlValue::from("foo"), YamlValue::from(i64::MAX)].iter() {
+        assert_conversion_fails(&converter, &typ, &data);
+    }
+}
+
+#[test]
 fn can_convert_u32() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat32);
@@ -69,6 +119,15 @@ fn can_convert_u32() {
         let data = YamlValue::from(*value);
         let expected_result = IDLValue::Nat32(*value);
         assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}
+
+#[test]
+fn conversion_to_u32_should_fail_for_some_inputs() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat32);
+    for data in [YamlValue::from("foo"), YamlValue::from(i64::MAX)].iter() {
+        assert_conversion_fails(&converter, &typ, &data);
     }
 }
 

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -56,7 +56,13 @@ fn can_convert_i8() {
 fn conversion_to_i8_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Int8);
-    for data in [YamlValue::from("foo"), YamlValue::from(i64::MAX)].iter() {
+    for data in [
+        YamlValue::from("foo"),
+        YamlValue::from(i64::MAX),
+        YamlValue::from(0.5),
+    ]
+    .iter()
+    {
         assert_conversion_fails(&converter, &typ, data);
     }
 }
@@ -76,7 +82,13 @@ fn can_convert_u8() {
 fn conversion_to_u8_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat8);
-    for data in [YamlValue::from("foo"), YamlValue::from(i64::MAX)].iter() {
+    for data in [
+        YamlValue::from("foo"),
+        YamlValue::from(i64::MAX),
+        YamlValue::from(0.5),
+    ]
+    .iter()
+    {
         assert_conversion_fails(&converter, &typ, data);
     }
 }
@@ -96,7 +108,13 @@ fn can_convert_i16() {
 fn conversion_to_i16_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Int16);
-    for data in [YamlValue::from("foo"), YamlValue::from(i64::MAX)].iter() {
+    for data in [
+        YamlValue::from("foo"),
+        YamlValue::from(i64::MAX),
+        YamlValue::from(0.5),
+    ]
+    .iter()
+    {
         assert_conversion_fails(&converter, &typ, data);
     }
 }
@@ -116,7 +134,13 @@ fn can_convert_u16() {
 fn conversion_to_u16_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat16);
-    for data in [YamlValue::from("foo"), YamlValue::from(i64::MAX)].iter() {
+    for data in [
+        YamlValue::from("foo"),
+        YamlValue::from(i64::MAX),
+        YamlValue::from(0.5),
+    ]
+    .iter()
+    {
         assert_conversion_fails(&converter, &typ, data);
     }
 }
@@ -136,7 +160,13 @@ fn can_convert_i32() {
 fn conversion_to_i32_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Int32);
-    for data in [YamlValue::from("foo"), YamlValue::from(i64::MAX)].iter() {
+    for data in [
+        YamlValue::from("foo"),
+        YamlValue::from(i64::MAX),
+        YamlValue::from(0.5),
+    ]
+    .iter()
+    {
         assert_conversion_fails(&converter, &typ, data);
     }
 }
@@ -156,7 +186,13 @@ fn can_convert_u32() {
 fn conversion_to_u32_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat32);
-    for data in [YamlValue::from("foo"), YamlValue::from(i64::MAX)].iter() {
+    for data in [
+        YamlValue::from("foo"),
+        YamlValue::from(i64::MAX),
+        YamlValue::from(0.5),
+    ]
+    .iter()
+    {
         assert_conversion_fails(&converter, &typ, data);
     }
 }
@@ -176,7 +212,13 @@ fn can_convert_i64() {
 fn conversion_to_i64_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Int64);
-    for data in [YamlValue::from("foo"), YamlValue::from(u64::MAX)].iter() {
+    for data in [
+        YamlValue::from("foo"),
+        YamlValue::from(u64::MAX),
+        YamlValue::from(0.5),
+    ]
+    .iter()
+    {
         assert_conversion_fails(&converter, &typ, data);
     }
 }
@@ -196,7 +238,13 @@ fn can_convert_u64() {
 fn conversion_to_u64_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat64);
-    for data in [YamlValue::from("foo"), YamlValue::from(-1)].iter() {
+    for data in [
+        YamlValue::from("foo"),
+        YamlValue::from(-1),
+        YamlValue::from(0.5),
+    ]
+    .iter()
+    {
         assert_conversion_fails(&converter, &typ, data);
     }
 }
@@ -227,7 +275,13 @@ fn can_convert_large_unsigned_ints_from_strings() {
 fn conversion_to_nat_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat64);
-    for data in [YamlValue::from("foo"), YamlValue::from(-1)].iter() {
+    for data in [
+        YamlValue::from("foo"),
+        YamlValue::from(-1),
+        YamlValue::from(0.5),
+    ]
+    .iter()
+    {
         assert_conversion_fails(&converter, &typ, data);
     }
 }
@@ -258,7 +312,13 @@ fn can_convert_large_ints_from_strings() {
 fn conversion_to_int_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat64);
-    for data in [YamlValue::from("foo"), YamlValue::Null].iter() {
+    for data in [
+        YamlValue::from("foo"),
+        YamlValue::Null,
+        YamlValue::from(0.5),
+    ]
+    .iter()
+    {
         assert_conversion_fails(&converter, &typ, data);
     }
 }
@@ -311,6 +371,25 @@ fn can_convert_bool() {
         let data = YamlValue::from(*value);
         let expected_result = IDLValue::Bool(*value);
         assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}
+
+#[test]
+fn can_convert_null() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Null);
+    let data = YamlValue::Null;
+    let expected_result = IDLValue::Null;
+    assert_conversion_is(&converter, &typ, &data, expected_result);
+}
+
+#[test]
+fn can_convert_reserved() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Reserved);
+    for data in [YamlValue::Null, YamlValue::from("foo"), YamlValue::from(6)].iter() {
+        let expected_result = IDLValue::Reserved;
+        assert_conversion_is(&converter, &typ, data, expected_result);
     }
 }
 

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -284,3 +284,31 @@ fn conversion_to_f64_should_fail_for_some_inputs() {
         assert_conversion_fails(&converter, &typ, data);
     }
 }
+
+#[test]
+fn can_convert_bool() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Bool);
+    for value in [true, false].iter() {
+        let data = YamlValue::from(*value);
+        let expected_result = IDLValue::Bool(*value);
+        assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}
+
+#[test]
+fn conversion_to_bool_should_fail_for_some_inputs() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Bool);
+    for data in [
+        YamlValue::from(0),
+        YamlValue::from(1),
+        YamlValue::from("FOO"),
+        YamlValue::from("true"),
+        YamlValue::from("false"),
+    ]
+    .iter()
+    {
+        assert_conversion_fails(&converter, &typ, data);
+    }
+}

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -4,6 +4,7 @@ use candid::types::{value::IDLField, Label};
 use candid_parser::types::TypeField;
 use num_bigint::{BigInt, BigUint};
 use pretty_assertions::assert_eq;
+use serde_yaml::Number;
 
 use super::{IDLType, IDLValue, Yaml2Candid, YamlValue};
 
@@ -403,6 +404,25 @@ fn conversion_to_bool_should_fail_for_some_inputs() {
         YamlValue::from("FOO"),
         YamlValue::from("true"),
         YamlValue::from("false"),
+    ]
+    .iter()
+    {
+        assert_conversion_fails(&converter, &typ, data);
+    }
+}
+
+#[test]
+fn conversion_to_empty_should_always_fail() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Empty);
+    for data in [
+        YamlValue::from(0),
+        YamlValue::from(1),
+        YamlValue::from("FOO"),
+        YamlValue::Bool(true),
+        YamlValue::Bool(false),
+        YamlValue::Number(Number::from(8)),
+        YamlValue::Null,
     ]
     .iter()
     {

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -28,3 +28,25 @@ fn can_convert_u8() {
         assert_conversion_is(&converter, &typ, &data, expected_result);
     }
 }
+
+#[cfg(test)]
+fn can_convert_i16() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Int16);
+    for value in [i16::MIN, -1, 0, 1, i16::MAX].iter() {
+        let data = YamlValue::from(*value);
+        let expected_result = IDLValue::Int16(*value);
+        assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}
+
+#[cfg(test)]
+fn can_convert_u16() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat16);
+    for value in [0, 1, u16::MAX].iter() {
+        let data = YamlValue::from(*value);
+        let expected_result = IDLValue::Nat16(*value);
+        assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -480,6 +480,20 @@ fn can_convert() {
             }]),
         },
         TestVec {
+            description: "Record containing None in conventional form (omission)",
+            typ: IDLType::RecordT(vec![TypeField {
+                label: Label::Named("Foo".to_string()),
+                typ: IDLType::OptT(Box::new(IDLType::PrimT(
+                    candid_parser::types::PrimType::Int8,
+                ))),
+            }]),
+            data: YamlValue::Mapping([].into_iter().collect()),
+            expected_result: IDLValue::Record(vec![IDLField {
+                id: Label::Named("Foo".to_string()),
+                val: IDLValue::None,
+            }]),
+        },
+        TestVec {
             description: "Record containing Some(5) in canonical form",
             typ: IDLType::RecordT(vec![TypeField {
                 label: Label::Named("Foo".to_string()),
@@ -498,6 +512,45 @@ fn can_convert() {
             expected_result: IDLValue::Record(vec![IDLField {
                 id: Label::Named("Foo".to_string()),
                 val: IDLValue::Opt(Box::new(IDLValue::Int8(8))),
+            }]),
+        },
+        TestVec {
+            description: "Record containing Some(5) in conventional form",
+            typ: IDLType::RecordT(vec![TypeField {
+                label: Label::Named("Foo".to_string()),
+                typ: IDLType::OptT(Box::new(IDLType::PrimT(
+                    candid_parser::types::PrimType::Int8,
+                ))),
+            }]),
+            data: YamlValue::Mapping(
+                [(YamlValue::from("Foo"), YamlValue::from(8))]
+                    .into_iter()
+                    .collect(),
+            ),
+            expected_result: IDLValue::Record(vec![IDLField {
+                id: Label::Named("Foo".to_string()),
+                val: IDLValue::Opt(Box::new(IDLValue::Int8(8))),
+            }]),
+        },
+        TestVec {
+            description: "Record containing Some([5]) in conventional form",
+            typ: IDLType::RecordT(vec![TypeField {
+                label: Label::Named("Foo".to_string()),
+                typ: IDLType::OptT(Box::new(IDLType::VecT(Box::new(IDLType::PrimT(
+                    candid_parser::types::PrimType::Int8,
+                ))))),
+            }]),
+            data: YamlValue::Mapping(
+                [(
+                    YamlValue::from("Foo"),
+                    YamlValue::Sequence(vec![YamlValue::from(8)]),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            expected_result: IDLValue::Record(vec![IDLField {
+                id: Label::Named("Foo".to_string()),
+                val: IDLValue::Opt(Box::new(IDLValue::Vec(vec![IDLValue::Int8(8)]))),
             }]),
         },
     ];

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -1,21 +1,29 @@
 //! Tests converting from YAML to Candid.
-use super::{Yaml2Candid, IDLType, IDLValue, YamlValue};
+use super::{IDLType, IDLValue, Yaml2Candid, YamlValue};
 
-fn assert_conversion_is(converter: &Yaml2Candid, typ: &IDLType, data: &YamlValue, expected_result: IDLValue) {
+fn assert_conversion_is(
+    converter: &Yaml2Candid,
+    typ: &IDLType,
+    data: &YamlValue,
+    expected_result: IDLValue,
+) {
     let result = converter.convert(typ, data).unwrap();
     assert_eq!(result, expected_result);
 }
 
 fn assert_conversion_fails(converter: &Yaml2Candid, typ: &IDLType, data: &YamlValue) {
     let result = converter.convert(typ, data);
-    assert!(result.is_err(), "Converting {data:?} to {typ:?} should fail.");
+    assert!(
+        result.is_err(),
+        "Converting {data:?} to {typ:?} should fail."
+    );
 }
 
 #[test]
 fn can_convert_i8() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Int8);
-    for value in [i8::MIN, i8::MIN+1, -1, 0, 1, i8::MAX-1, i8::MAX].iter() {
+    for value in [i8::MIN, i8::MIN + 1, -1, 0, 1, i8::MAX - 1, i8::MAX].iter() {
         let data = YamlValue::from(*value);
         let expected_result = IDLValue::Int8(*value);
         assert_conversion_is(&converter, &typ, &data, expected_result);
@@ -35,7 +43,7 @@ fn conversion_to_i8_should_fail_for_some_inputs() {
 fn can_convert_u8() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat8);
-    for value in [0, 1, u8::MAX -1, u8::MAX].iter() {
+    for value in [0, 1, u8::MAX - 1, u8::MAX].iter() {
         let data = YamlValue::from(*value);
         let expected_result = IDLValue::Nat8(*value);
         assert_conversion_is(&converter, &typ, &data, expected_result);
@@ -55,7 +63,7 @@ fn conversion_to_u8_should_fail_for_some_inputs() {
 fn can_convert_i16() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Int16);
-    for value in [i16::MIN, i16::MIN+1, -1, 0, 1, i16::MAX-1, i16::MAX].iter() {
+    for value in [i16::MIN, i16::MIN + 1, -1, 0, 1, i16::MAX - 1, i16::MAX].iter() {
         let data = YamlValue::from(*value);
         let expected_result = IDLValue::Int16(*value);
         assert_conversion_is(&converter, &typ, &data, expected_result);
@@ -75,7 +83,7 @@ fn conversion_to_i16_should_fail_for_some_inputs() {
 fn can_convert_u16() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat16);
-    for value in [0, 1, u16::MAX-1, u16::MAX].iter() {
+    for value in [0, 1, u16::MAX - 1, u16::MAX].iter() {
         let data = YamlValue::from(*value);
         let expected_result = IDLValue::Nat16(*value);
         assert_conversion_is(&converter, &typ, &data, expected_result);
@@ -95,7 +103,7 @@ fn conversion_to_u16_should_fail_for_some_inputs() {
 fn can_convert_i32() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Int32);
-    for value in [i32::MIN, i32::MIN+1, -1, 0, 1, i32::MAX].iter() {
+    for value in [i32::MIN, i32::MIN + 1, -1, 0, 1, i32::MAX].iter() {
         let data = YamlValue::from(*value);
         let expected_result = IDLValue::Int32(*value);
         assert_conversion_is(&converter, &typ, &data, expected_result);
@@ -115,7 +123,7 @@ fn conversion_to_i32_should_fail_for_some_inputs() {
 fn can_convert_u32() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat32);
-    for value in [0, 1, u32::MAX-1, u32::MAX].iter() {
+    for value in [0, 1, u32::MAX - 1, u32::MAX].iter() {
         let data = YamlValue::from(*value);
         let expected_result = IDLValue::Nat32(*value);
         assert_conversion_is(&converter, &typ, &data, expected_result);
@@ -135,10 +143,19 @@ fn conversion_to_u32_should_fail_for_some_inputs() {
 fn can_convert_i64() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Int64);
-    for value in [i64::MIN, i64::MIN+1, -1, 0, 1, i64::MAX].iter() {
+    for value in [i64::MIN, i64::MIN + 1, -1, 0, 1, i64::MAX].iter() {
         let data = YamlValue::from(*value);
         let expected_result = IDLValue::Int64(*value);
         assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}
+
+#[test]
+fn conversion_to_i64_should_fail_for_some_inputs() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Int64);
+    for data in [YamlValue::from("foo"), YamlValue::from(u64::MAX)].iter() {
+        assert_conversion_fails(&converter, &typ, &data);
     }
 }
 
@@ -150,5 +167,14 @@ fn can_convert_u64() {
         let data = YamlValue::from(*value);
         let expected_result = IDLValue::Nat64(*value);
         assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}
+
+#[test]
+fn conversion_to_u64_should_fail_for_some_inputs() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat8);
+    for data in [YamlValue::from("foo"), YamlValue::from(-1)].iter() {
+        assert_conversion_fails(&converter, &typ, &data);
     }
 }

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -7,67 +7,89 @@ fn assert_conversion_is(converter: &Yaml2Candid, typ: &IDLType, data: &YamlValue
 }
 
 
-#[cfg(test)]
+#[test]
 fn can_convert_i8() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Int8);
-    for value in [i8::MIN, -1, 0, 1, i8::MAX].iter() {
+    for value in [i8::MIN, i8::MIN+1, -1, 0, 1, i8::MAX-1, i8::MAX].iter() {
         let data = YamlValue::from(*value);
         let expected_result = IDLValue::Int8(*value);
         assert_conversion_is(&converter, &typ, &data, expected_result);
     }
 }
 
-#[cfg(test)]
+#[test]
 fn can_convert_u8() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat8);
-    for value in [0, 1, u8::MAX].iter() {
+    for value in [0, 1, u8::MAX -1, u8::MAX].iter() {
         let data = YamlValue::from(*value);
         let expected_result = IDLValue::Nat8(*value);
         assert_conversion_is(&converter, &typ, &data, expected_result);
     }
 }
 
-#[cfg(test)]
+#[test]
 fn can_convert_i16() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Int16);
-    for value in [i16::MIN, -1, 0, 1, i16::MAX].iter() {
+    for value in [i16::MIN, i16::MIN+1, -1, 0, 1, i16::MAX-1, i16::MAX].iter() {
         let data = YamlValue::from(*value);
         let expected_result = IDLValue::Int16(*value);
         assert_conversion_is(&converter, &typ, &data, expected_result);
     }
 }
 
-#[cfg(test)]
+#[test]
 fn can_convert_u16() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat16);
-    for value in [0, 1, u16::MAX].iter() {
+    for value in [0, 1, u16::MAX-1, u16::MAX].iter() {
         let data = YamlValue::from(*value);
         let expected_result = IDLValue::Nat16(*value);
         assert_conversion_is(&converter, &typ, &data, expected_result);
     }
 }
-#[cfg(test)]
+#[test]
 fn can_convert_i32() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Int32);
-    for value in [i32::MIN, -1, 0, 1, i32::MAX].iter() {
+    for value in [i32::MIN, i32::MIN+1, -1, 0, 1, i32::MAX].iter() {
         let data = YamlValue::from(*value);
         let expected_result = IDLValue::Int32(*value);
         assert_conversion_is(&converter, &typ, &data, expected_result);
     }
 }
 
-#[cfg(test)]
+#[test]
 fn can_convert_u32() {
     let converter = Yaml2Candid::default();
     let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat32);
-    for value in [0, 1, u32::MAX].iter() {
+    for value in [0, 1, u32::MAX-1, u32::MAX].iter() {
         let data = YamlValue::from(*value);
         let expected_result = IDLValue::Nat32(*value);
+        assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}
+
+#[test]
+fn can_convert_i64() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Int64);
+    for value in [i64::MIN, i64::MIN+1, -1, 0, 1, i64::MAX].iter() {
+        let data = YamlValue::from(*value);
+        let expected_result = IDLValue::Int64(*value);
+        assert_conversion_is(&converter, &typ, &data, expected_result);
+    }
+}
+
+#[test]
+fn can_convert_u64() {
+    let converter = Yaml2Candid::default();
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat64);
+    for value in [0, 1, u64::MAX].iter() {
+        let data = YamlValue::from(*value);
+        let expected_result = IDLValue::Nat64(*value);
         assert_conversion_is(&converter, &typ, &data, expected_result);
     }
 }

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -275,7 +275,7 @@ fn can_convert_large_unsigned_ints_from_strings() {
 #[test]
 fn conversion_to_nat_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
-    let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat64);
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat);
     for data in [
         YamlValue::from("foo"),
         YamlValue::from(-1),
@@ -312,7 +312,7 @@ fn can_convert_large_ints_from_strings() {
 #[test]
 fn conversion_to_int_should_fail_for_some_inputs() {
     let converter = Yaml2Candid::default();
-    let typ = IDLType::PrimT(candid_parser::types::PrimType::Nat64);
+    let typ = IDLType::PrimT(candid_parser::types::PrimType::Int);
     for data in [
         YamlValue::from("foo"),
         YamlValue::Null,

--- a/src/yaml2candid/tests/nns-sns-wasm.rs
+++ b/src/yaml2candid/tests/nns-sns-wasm.rs
@@ -1,4 +1,5 @@
 use candid_parser::types::IDLType;
+use pretty_assertions::assert_eq;
 use serde_yaml::Value as YamlValue;
 use yaml2candid::Yaml2Candid;
 

--- a/src/yaml2candid/tests/nns-sns-wasm/SnsInitPayload.idl
+++ b/src/yaml2candid/tests/nns-sns-wasm/SnsInitPayload.idl
@@ -1,60 +1,60 @@
 record {
-  url = "http://sgymv-uiaaa-aaaaa-aaaia-cai.localhost:8080/";
-  max_dissolve_delay_seconds = 252_460_800 : nat64;
-  max_dissolve_delay_bonus_percentage = 0 : nat64;
+  url = opt "http://sgymv-uiaaa-aaaaa-aaaia-cai.localhost:8080/";
+  max_dissolve_delay_seconds = opt (252_460_800 : nat64);
+  max_dissolve_delay_bonus_percentage = opt (0 : nat64);
   fallback_controller_principal_ids = vec {
     "hpikg-6exdt-jn33w-ndty3-fc7jc-tl2lr-buih3-cs3y7-tftkp-sfp62-gqe";
   };
-  token_symbol = "LANUW";
+  token_symbol = opt "LANUW";
   final_reward_rate_basis_points = null;
-  neuron_minimum_stake_e8s = 100_000 : nat64;
-  logo = "logo.svg";
-  name = "LANUW";
-  initial_voting_period_seconds = 345_600 : nat64;
-  neuron_minimum_dissolve_delay_to_vote_seconds = 15_778_800 : nat64;
-  description = "This is my awesome project";
-  max_neuron_age_seconds_for_age_bonus = 126_230_400 : nat64;
+  neuron_minimum_stake_e8s = opt (100_000 : nat64);
+  logo = opt "logo.svg";
+  name = opt "LANUW";
+  initial_voting_period_seconds = opt (345_600 : nat64);
+  neuron_minimum_dissolve_delay_to_vote_seconds = opt (15_778_800 : nat64);
+  description = opt "This is my awesome project";
+  max_neuron_age_seconds_for_age_bonus = opt (126_230_400 : nat64);
   initial_reward_rate_basis_points = null;
-  wait_for_quiet_deadline_increase_seconds = 86_400 : nat64;
-  transaction_fee_e8s = 10_000 : nat64;
+  wait_for_quiet_deadline_increase_seconds = opt (86_400 : nat64);
+  transaction_fee_e8s = opt (10_000 : nat64);
   sns_initialization_parameters = null;
   max_age_bonus_percentage = null;
-  initial_token_distribution = variant {
+  initial_token_distribution = opt variant {
     FractionalDeveloperVotingPower = record {
-      treasury_distribution = record { total_e8s = 5_000_000_000 : nat64 };
-      developer_distribution = record {
+      treasury_distribution = opt record { total_e8s = 5_000_000_000 : nat64 };
+      developer_distribution = opt record {
         developer_neurons = vec {
           record {
-            controller = principal "x4vjn-rrapj-c2kqe-a6m2b-7pzdl-ntmc4-riutz-5bylw-2q2bh-ds5h2-lae";
+            controller = opt principal "x4vjn-rrapj-c2kqe-a6m2b-7pzdl-ntmc4-riutz-5bylw-2q2bh-ds5h2-lae";
             dissolve_delay_seconds = 15_780_000 : nat64;
             memo = 0 : nat64;
             stake_e8s = 1_500_000_000 : nat64;
           };
           record {
-            controller = principal "fod6j-klqsi-ljm4t-7v54x-2wd6s-6yduy-spdkk-d2vd4-iet7k-nakfi-qqe";
+            controller = opt principal "fod6j-klqsi-ljm4t-7v54x-2wd6s-6yduy-spdkk-d2vd4-iet7k-nakfi-qqe";
             dissolve_delay_seconds = 31_560_000 : nat64;
             memo = 1 : nat64;
             stake_e8s = 1_500_000_000 : nat64;
           };
         };
       };
-      airdrop_distribution = record {
+      airdrop_distribution = opt record {
         airdrop_neurons = vec {
           record {
-            controller = principal "fod6j-klqsi-ljm4t-7v54x-2wd6s-6yduy-spdkk-d2vd4-iet7k-nakfi-qqe";
+            controller = opt principal "fod6j-klqsi-ljm4t-7v54x-2wd6s-6yduy-spdkk-d2vd4-iet7k-nakfi-qqe";
             dissolve_delay_seconds = 15_780_000 : nat64;
             memo = 0 : nat64;
             stake_e8s = 500_000_000 : nat64;
           };
         };
       };
-      swap_distribution = record {
+      swap_distribution = opt record {
         total_e8s = 6_000_000_000 : nat64;
         initial_swap_amount_e8s = 200_000_000 : nat64;
       };
     }
   };
-  reward_rate_transition_duration_seconds = 1 : nat64;
-  token_name = "maxs awesome LANUW";
-  proposal_reject_cost_e8s = 100_000_000 : nat64;
+  reward_rate_transition_duration_seconds = opt (1 : nat64);
+  token_name = opt "maxs awesome LANUW";
+  proposal_reject_cost_e8s = opt (100_000_000 : nat64);
 }


### PR DESCRIPTION
# Motivation
`yaml2candid` is very incomplete and still in some places buggy.  Specifically, it does not support many Candid types and the opt test vectors (and implementation that was guided by those test vectors) are wrong.

# Changes
- Restructure the main `yaml2json` type match so that the compiler will complain when not all types are matched.
- Add YAML to Candid conversions for almost all missing Candid types.  Service and class are still unsupported.  I am running out of time and these are both complicated and not needed for my immediate goal.
- Add lots of tests.
- Fix the existing test vector that didn't include `opt` in the candid.

# Tests
- Fairly comprehensive unit tests are included for each individual type.
- Test coverage was checked with Tarpaulin; the tarpaulin report is generated by CI and can be checked.
- Most but not all error branches are tested.

# TODO in future
- Ensure that failures have useful error messages.
- Use proptests to ensure that no corner cases have been overlooked.
- Perhaps get more test vectors from real-life use to ensure that the test vectors are consistent with conventional usage.