### PR TITLE
fix (yaml2candid): Error message indicates where the conversion failed

### DIFF
--- a/src/yaml2candid_cli/src/bin/yaml2candid.rs
+++ b/src/yaml2candid_cli/src/bin/yaml2candid.rs
@@ -22,9 +22,11 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
-    let converter = Yaml2Candid::from_did_file(&args.did).unwrap();
+    let converter = Yaml2Candid::from_did_file(&args.did).expect("Failed to parse .did file");
     let yaml_str = file2string(args.yml);
-    let candid = converter.convert_str(&args.typ, &yaml_str).unwrap();
+    let candid = converter
+        .convert_str(&args.typ, &yaml_str)
+        .expect("Failed to convert YAML to idl");
     println!("{candid}")
 }
 


### PR DESCRIPTION
# Motivation
If a `yaml2candid` conversion fails to convert some element deep inside a Yaml file into the requested Candid type, the current error message provides no contextual information to communicate where the conversion failed.

For example, if this fails to convert to Candid because the candid spec expects a vector of bytes where we have "man":
```
foo:
  bar:
    bat: man
```
then the error is:
```
called `Result::unwrap()` on an `Err` value: Expected a sequence for vec type, got: String("man")
```
Add a few more superheroes and it can easily become hard to tell whether the villain in disguise is spiderman, batman aquaman or some other .*man.

Ideally the error message should state on which line and character the conversion failed.  This could be done, theoretically, if the YAML is converted as it is parsed.  I have not managed to do this.  (Admittedly in limited time, given more time it may be possible.)  A poor man's alternative is at least to provide a path to the failing element.  The path is the sequence of array indices and dictionary keys leading to the failing element.

The error type of the `yaml2candid` library is `anyhow`, so the path is added as anyhow context.  It would probably be nicer to have a custom error type that can be displayed more beautifully.  However that would be a breaking change and the anyhow messages do convey the essential information.

# Changes
- Provide the path to a YAML element that could not be converted to candid.
- Use `.expect()` rather than `.unwrap()` to provide a cleaner error message.

# Tests
Here is an example error - not very pretty - that does however provide the path to the failing element:
```
$ echo '[{"foo": {"bar": {"bat": [[8]]}}}, {"foo": {"bar": {"spider": "woman"}}}]' | yaml2candid --did ./foo.did --typ LotsOfMen
Failed to convert YAML to idl: Failed to convert element #1

Caused by:
    0: Failed to parse value for key 'foo'
    1: Failed to parse value for key 'bar'
    2: Failed to parse value for key 'spider'
    3: Expected a sequence for vec type, got: String("woman")
```