### PR TITLE
feat (yaml2candid): Support blobs input as hex or base64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,8 +1368,10 @@ name = "yaml2candid"
 version = "0.10.1"
 dependencies = [
  "anyhow",
+ "base64",
  "candid",
  "candid_parser",
+ "hex",
  "num-bigint",
  "pretty_assertions",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ resolver = "2"
 version = "0.10.1"
 
 [workspace.dependencies]
+base64 = { version = "0.22.1" }
 candid = { version = "0.10.8" }
 candid_parser = { version = "0.1.0" }
-num-bigint = { version = "0.4.5" }
-base64 = { version = "0.22.1" }
 hex = { version = "0.4.3" }
+num-bigint = { version = "0.4.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,5 @@ version = "0.10.1"
 candid = { version = "0.10.8" }
 candid_parser = { version = "0.1.0" }
 num-bigint = { version = "0.4.5" }
+base64 = { version = "0.22.1" }
+hex = { version = "0.4.3" }

--- a/src/idl2json/Cargo.toml
+++ b/src/idl2json/Cargo.toml
@@ -12,20 +12,19 @@ readme = "../../README.md"
 
 categories = ["encoding", "parsing"]
 keywords = ["internet-computer", "idl", "candid", "dfinity", "json"]
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 candid = { workspace = true }
 candid_parser = { workspace = true }
+clap = { version = "4", features = [ "derive" ], optional = true }
 serde_json = "^1.0"
 sha2 = { version = "0.10.8", optional = true }
-clap = { version = "4", features = [ "derive" ], optional = true }
 
 [dev-dependencies]
 json-patch = "0.2.7"
-serde = "1"
 num-bigint = "0.4.6"
+serde = "1"
 
 [features]
 default = ["crypto"]

--- a/src/idl2json_cli/Cargo.toml
+++ b/src/idl2json_cli/Cargo.toml
@@ -12,7 +12,6 @@ readme = "../../README.md"
 
 categories = ["encoding", "parsing"]
 keywords = ["internet-computer", "idl", "candid", "dfinity", "json"]
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [[bin]]
@@ -20,13 +19,13 @@ name = "idl2json"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1"
 candid = { workspace = true }
 candid_parser = { workspace = true }
 clap = { version = "4.5.8", features = [ "derive" ] }
 fn-error-context = "0.2.1"
+idl2json = { path = "../idl2json", version = "0.10.1", features = ["clap", "crypto"] }
 serde_json = "^1.0"
-idl2json = { path = "../idl2json", version="0.10.1", features = ["clap", "crypto"] }
-anyhow = "1"
 
 [build-dependencies]
 anyhow = "1"

--- a/src/yaml2candid/Cargo.toml
+++ b/src/yaml2candid/Cargo.toml
@@ -2,16 +2,17 @@
 name = "yaml2candid"
 version = { workspace = true }
 edition = "2021"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1"
+base64 = { workspace = true }
 candid = { workspace = true }
 candid_parser = { workspace = true }
+hex = { workspace = true }
+num-bigint = { workspace = true }
 serde = "1"
 serde_yaml = "0.9"
-anyhow = "1"
-num-bigint = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -495,6 +495,38 @@ fn can_convert() {
             ]),
         },
         TestVec {
+            description: "hex encoded blob",
+            typ: IDLType::VecT(Box::new(IDLType::PrimT(
+                candid_parser::types::PrimType::Nat8,
+            ))),
+            data: YamlValue::from("0x010203090a1000"),
+            expected_result: IDLValue::Vec(vec![
+                IDLValue::Nat8(1),
+                IDLValue::Nat8(2),
+                IDLValue::Nat8(3),
+                IDLValue::Nat8(9),
+                IDLValue::Nat8(10),
+                IDLValue::Nat8(16),
+                IDLValue::Nat8(0),
+            ]),
+        },
+        TestVec {
+            description: "base64 encoded blob",
+            typ: IDLType::VecT(Box::new(IDLType::PrimT(
+                candid_parser::types::PrimType::Nat8,
+            ))),
+            data: YamlValue::from("base64,AQIDCQoQAA=="),
+            expected_result: IDLValue::Vec(vec![
+                IDLValue::Nat8(1),
+                IDLValue::Nat8(2),
+                IDLValue::Nat8(3),
+                IDLValue::Nat8(9),
+                IDLValue::Nat8(10),
+                IDLValue::Nat8(16),
+                IDLValue::Nat8(0),
+            ]),
+        },
+        TestVec {
             description: "Some(5) in canonical form",
             typ: IDLType::OptT(Box::new(IDLType::PrimT(
                 candid_parser::types::PrimType::Int8,

--- a/src/yaml2candid/src/test.rs
+++ b/src/yaml2candid/src/test.rs
@@ -1,4 +1,5 @@
 //! Tests converting from YAML to Candid, especially extreme values of primitive types.
+#![allow(clippy::panic)] // Tests are allowed to panic!
 use anyhow::Context;
 use candid::types::{value::IDLField, Label};
 use candid_parser::types::TypeField;

--- a/src/yaml2candid_cli/Cargo.toml
+++ b/src/yaml2candid_cli/Cargo.toml
@@ -2,7 +2,6 @@
 name = "yaml2candid_cli"
 version = { workspace = true }
 edition = "2021"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
# Motivation
`idl2json` supports encoding blobs as hex but the reverse is not true: `yaml2candid` does not accept byte arrays expressed as hex.  This is inconvenient, to put it mildly.

# Changes
- Support blobs expressed as hex or base64.

# Tests
- Unit tests are included with 100% code coverage of the added lines.